### PR TITLE
fix: keep addresses trigger active state when dropdown is open

### DIFF
--- a/src/shared/components/header/Header.tsx
+++ b/src/shared/components/header/Header.tsx
@@ -120,6 +120,7 @@ export const Header = () => {
                 onClick={handleAddressDropdownClick}
                 onKeyDown={(e) => handleSubmitKeyAction(e, handleAddressDropdownClick)}
                 tabIndex={0}
+                selected={showAddressesDropdown}
                 aria-label='Addresses Dropdown'
               >
                 <Alias color='base' maxWidth='124px' fontWeight='medium' as='span'>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86drpnjek

![Screenshot from 2024-02-27 14-35-31](https://github.com/ArdentHQ/arkconnect-extension/assets/132887516/be7855b6-5be6-422c-b652-7cf07153f8b6)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
