### PR TITLE
fix: incorrect color references

### DIFF
--- a/src/components/wallet/TestnetLabel.tsx
+++ b/src/components/wallet/TestnetLabel.tsx
@@ -14,8 +14,8 @@ const TestnetLabel = () => {
 const StyledLabel = styled(Container)`
     transition: all 0.3s ease-in-out;
     ${({ theme }) => `
-    color: ${theme.color.warning};
-    border: 1px solid ${theme.color.warning};
+    color: ${theme.colors.warning};
+    border: 1px solid ${theme.colors.warning};
   `}
 
     border-radius: 8px;

--- a/src/shared/components/input/Checkbox.tsx
+++ b/src/shared/components/input/Checkbox.tsx
@@ -87,7 +87,7 @@ const Indicator = styled.span<{
     ${
         isFocusWithin &&
         `
-        outline-color: ${theme.color.primary600};
+        outline-color: ${theme.colors.primary600};
         outline-style: solid;
         outline-width: 2px;
         outline-offset: 2px;

--- a/src/shared/components/input/RadioButton.tsx
+++ b/src/shared/components/input/RadioButton.tsx
@@ -84,7 +84,7 @@ const Indicator = styled.div<{
     ${
         isFocusWithin &&
         `
-        outline-color: ${theme.color.primary600};
+        outline-color: ${theme.colors.primary600};
         outline-style: solid;
         outline-width: 2px;
         outline-offset: 2px;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86drk4r60

When tabbing into the Addresses dropdown and tabbing down the addresses, it would trigger an error for `primary600` when focusing on the Radio button. I believe this is from when I fixed the Firefox outline colour - https://app.clickup.com/t/86drkyb5h

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
