### PR TITLE
fix: set mainnet network as default when resetting profile

### DIFF
--- a/src/lib/context/Profile.tsx
+++ b/src/lib/context/Profile.tsx
@@ -9,6 +9,7 @@ import * as SessionStore from '@/lib/store/session';
 import { useWalletBalance } from '../hooks/useWalletBalance';
 import { ProfileData } from '../background/contracts';
 import { LoadingFullScreen } from '@/shared/components/handleStates/LoadingFullScreen';
+import { testnetEnabledChanged } from '../store/ui';
 
 interface Context {
     profile: Contracts.IProfile;
@@ -76,6 +77,10 @@ export const ProfileProvider = ({ children }: Properties) => {
 
             const profile = await importProfile(data);
             profile.data().fill(profileData);
+
+            if (profile.wallets().count() === 0) {
+                dispatch(testnetEnabledChanged(false));
+            }
 
             await updateStore({ profile });
         } catch (error) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/86drqeye7
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
