### PR TITLE
fix: import address padding

### DIFF
--- a/src/components/ledger/LedgerConnectionStep.tsx
+++ b/src/components/ledger/LedgerConnectionStep.tsx
@@ -95,7 +95,7 @@ export const LedgerConnectionStep = ({
     );
 
     return (
-        <Container>
+        <Container px='24'>
             <Heading $typeset='h3' fontWeight='bold' color='base' mb='24'>
                 Connect Your Ledger Device
             </Heading>

--- a/src/components/ledger/LedgerConnectionStep.tsx
+++ b/src/components/ledger/LedgerConnectionStep.tsx
@@ -95,7 +95,7 @@ export const LedgerConnectionStep = ({
     );
 
     return (
-        <Container px='24'>
+        <Container>
             <Heading $typeset='h3' fontWeight='bold' color='base' mb='24'>
                 Connect Your Ledger Device
             </Heading>

--- a/src/components/steps/StepsNavigation.tsx
+++ b/src/components/steps/StepsNavigation.tsx
@@ -71,7 +71,7 @@ const StepsNavigation = <T extends Record<string, any>>({
                     </Paragraph>
                 </Container>
             </StyledFlexContainer>
-            <FlexContainer flexDirection='column' height='100%' px={currentStep === 1 ? '0' : '24'}>
+            <FlexContainer flexDirection='column' height='100%'>
                 <CurrentStepComponent
                     goToNextStep={handleStepForward}
                     goToPrevStep={handleStepBack}

--- a/src/components/steps/StepsNavigation.tsx
+++ b/src/components/steps/StepsNavigation.tsx
@@ -72,7 +72,11 @@ const StepsNavigation = <T extends Record<string, any>>({
                     </Paragraph>
                 </Container>
             </StyledFlexContainer>
-            <FlexContainer flexDirection='column' height='100%' px={steps[currentStep].containerPaddingX}>
+            <FlexContainer
+                flexDirection='column'
+                height='100%'
+                px={steps[currentStep].containerPaddingX}
+            >
                 <CurrentStepComponent
                     goToNextStep={handleStepForward}
                     goToPrevStep={handleStepBack}

--- a/src/components/steps/StepsNavigation.tsx
+++ b/src/components/steps/StepsNavigation.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom';
 
 export type Step = {
     component: ComponentType<any>;
+    containerPaddingX?: '0' | '24';
 };
 
 type StepNavigationProps<T> = React.ComponentProps<typeof StyledFlexContainer> & {
@@ -71,7 +72,7 @@ const StepsNavigation = <T extends Record<string, any>>({
                     </Paragraph>
                 </Container>
             </StyledFlexContainer>
-            <FlexContainer flexDirection='column' height='100%'>
+            <FlexContainer flexDirection='column' height='100%' px={steps[currentStep].containerPaddingX}>
                 <CurrentStepComponent
                     goToNextStep={handleStepForward}
                     goToPrevStep={handleStepBack}

--- a/src/pages/ImportWithLedger.tsx
+++ b/src/pages/ImportWithLedger.tsx
@@ -97,7 +97,7 @@ const ImportWithLedger = () => {
         (async () => {
             const { hasOnboarded } = await getLocalValues();
             if (!hasOnboarded) {
-                setSteps([...steps, { component: SetupPassword, containerPaddingX: '24'  }]);
+                setSteps([...steps, { component: SetupPassword, containerPaddingX: '24' }]);
             }
         })();
     }, []);

--- a/src/pages/ImportWithLedger.tsx
+++ b/src/pages/ImportWithLedger.tsx
@@ -36,7 +36,7 @@ const ImportWithLedger = () => {
     const { error, removeErrors } = useLedgerContext();
     const { onError } = useErrorHandlerContext();
     const [steps, setSteps] = useState<Step[]>([
-        { component: LedgerConnectionStep },
+        { component: LedgerConnectionStep, containerPaddingX: '24' },
         { component: ImportWallets },
     ]);
     const loadingModal = useLoadingModal({
@@ -97,7 +97,7 @@ const ImportWithLedger = () => {
         (async () => {
             const { hasOnboarded } = await getLocalValues();
             if (!hasOnboarded) {
-                setSteps([...steps, { component: SetupPassword }]);
+                setSteps([...steps, { component: SetupPassword, containerPaddingX: '24'  }]);
             }
         })();
     }, []);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[extension] incorrect width used on Import and Create pages](https://app.clickup.com/t/86drqvh3u)

## Summary

- Padding from steps navigation have been removed.
- It has been applied to the connect ledger 1st step instead.

## Screenshots:

- Connect ledger:
<img width="449" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/694afb64-92d1-41fc-b2a0-3eb1c547adb9">

- Import address:
<img width="364" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/eae7898f-fb8e-4d8d-9208-c002e081fc37">



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
