### PR TITLE
fix: skip manifest validation

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,40 +14,41 @@ const manifest = process.env.BROWSER === 'firefox' ? firefoxManifest : chromeMan
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
-  process.env = { ...process.env, ...loadEnv(mode, process.cwd()) }; // Combine passed vars + .env
+    process.env = { ...process.env, ...loadEnv(mode, process.cwd()) }; // Combine passed vars + .env
 
-  return {
-    define: {
-      'process.env.NODE_DEBUG': process.env.NODE_DEBUG ? true : false,
-      'process.env.VITE_SEED_ADDRESSES': process.env.VITE_SEED_ADDRESSES ? true : false,
-    },
-    plugins: [
-      react(),
-      webExtension({
-        manifest: () => {
-          return {
-            name: pkg.name,
-            description: pkg.description,
-            version: pkg.version,
-            ...manifest,
-          };
+    return {
+        define: {
+            'process.env.NODE_DEBUG': process.env.NODE_DEBUG ? true : false,
+            'process.env.VITE_SEED_ADDRESSES': process.env.VITE_SEED_ADDRESSES ? true : false,
         },
-        additionalInputs: ['src/inpage.ts'],
-        webExtConfig: {
-          startUrl: process.env.VITE_START_URL ?? 'about:blank',
-          firefox: process.env.VITE_FIREFOX_BINARY,
+        plugins: [
+            react(),
+            webExtension({
+                manifest: () => {
+                    return {
+                        name: pkg.name,
+                        description: pkg.description,
+                        version: pkg.version,
+                        ...manifest,
+                    };
+                },
+                additionalInputs: ['src/inpage.ts'],
+                webExtConfig: {
+                    startUrl: process.env.VITE_START_URL ?? 'about:blank',
+                    firefox: process.env.VITE_FIREFOX_BINARY,
+                },
+                browser: process.env.BROWSER || 'chrome',
+                skipManifestValidation: true,
+            }),
+        ],
+        resolve: {
+            alias: {
+                '@': path.resolve(__dirname, 'src'),
+            },
         },
-        browser: process.env.BROWSER || 'chrome',
-      }),
-    ],
-    resolve: {
-      alias: {
-        '@': path.resolve(__dirname, 'src'),
-      },
-    },
-    test: {
-      environment: 'jsdom',
-      setupFiles: ['./vitest.setup.ts'],
-    },
-  };
+        test: {
+            environment: 'jsdom',
+            setupFiles: ['./vitest.setup.ts'],
+        },
+    };
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes https://app.clickup.com/t/86drrdyxd

After debugging the logs, I noticed that the issue was within the `vite-plugin-web-extension` code, specifically after making a call to this URL: `https://json.schemastore.org/chrome-manifest`. I assume the issue arises because that link is intermittently down.

By adding `skipManifestValidation`, we should be able to prevent this issue. As a side effect it seems that now is launching the browser earlier on dev mode which is nice. [See docs for details ->
](https://vite-plugin-web-extension.aklinker1.io/config/plugin-options.html#skipmanifestvalidation)
## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
