### PR TITLE
fix: adjust leading for each typeset

### DIFF
--- a/src/css/general.css
+++ b/src/css/general.css
@@ -1,13 +1,13 @@
 @layer base {
     p {
-        @apply leading-tight font-normal
+        @apply font-normal
     }
 
     .typeset-heading {
-        @apply text-base text-subtle-black dark:text-white
+        @apply text-base text-subtle-black dark:text-white leading-5
     }
 
     .typeset-body {
-        @apply text-sm text-theme-secondary-600 dark:text-theme-secondary-300
+        @apply text-sm text-theme-secondary-600 dark:text-theme-secondary-300 leading-[17.5px]
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[fix] use of leading class for typesets](https://app.clickup.com/t/86drtbxh5)

## Summary

- Based on current designs, the leading for each typeset has been specifically set instead of using a general percentage.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
