### PR TITLE
fix: disconnect icon color

### DIFF
--- a/src/components/connections/ConnectionsList.tsx
+++ b/src/components/connections/ConnectionsList.tsx
@@ -128,7 +128,7 @@ const ConnectionsList = () => {
                                 >
                                     <Icon
                                         icon='slash'
-                                        className='text-light-black dark:text-white w-4.5 h-4.5'
+                                        className='text-theme-error-600 dark:text-theme-error-500 w-4.5 h-4.5'
                                     />
                                 </StyledFlexContainer>
                             </Tooltip>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[connected apps] change disconnect icon to red](https://app.clickup.com/t/86drtd6pw)

## Summary

- Disconnect icon is now red as in the designs.

<img width="362" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/a26056b1-4c12-413e-b10a-ae65dfae8c96">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
