### PR TITLE
fix: color for 'yes' button in disconnect modal

### DIFF
--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -106,7 +106,7 @@
 
     /** Button Destructive Secondary **/
     .button-destructiveSecondary {
-        @apply border border-solid border-theme-error-600 bg-white dark:border-theme-error-500 dark:bg-light-black;
+        @apply border border-solid border-theme-error-600 bg-white font-medium text-theme-error-600 dark:text-theme-error-500 dark:border-theme-error-500 dark:bg-light-black;
     }
     .button-destructiveSecondary:hover {
         @apply bg-theme-error-50 dark:bg-[rgba(91,16,5,0.08)];

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -106,7 +106,7 @@
 
     /** Button Destructive Secondary **/
     .button-destructiveSecondary {
-        @apply border border-solid border-theme-error-600 bg-white font-medium text-theme-error-600 dark:text-theme-error-500 dark:border-theme-error-500 dark:bg-light-black;
+        @apply border border-solid border-theme-error-600 bg-white font-medium text-theme-error-600 dark:border-theme-error-500 dark:bg-light-black dark:text-theme-error-500;
     }
     .button-destructiveSecondary:hover {
         @apply bg-theme-error-50 dark:bg-[rgba(91,16,5,0.08)];


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [https://app.clickup.com/t/86dru64yp](https://app.clickup.com/t/86dru64yp)

## Summary

- Color for `yes` button in Disconnect modal has been fixed and is now red.
- 
<img width="365" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/1ee050e6-1774-48ad-8bb8-8c28c8268877">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
