### PR TITLE
fix: address dropdown closes on outside click

### DIFF
--- a/src/shared/components/header/AddressesDropdown.tsx
+++ b/src/shared/components/header/AddressesDropdown.tsx
@@ -66,7 +66,7 @@ export const AddressesDropdown = ({
     };
 
     return (
-        <div className=' mx-4 w-full rounded-xl bg-white shadow-dropdown dark:bg-subtle-black'>
+        <div className='mx-4 w-full rounded-xl bg-white shadow-dropdown dark:bg-subtle-black' ref={dropdownRef}>
             <div className='border-b border-solid border-b-theme-secondary-200 dark:border-b-theme-secondary-600'>
                 <div className=' flex items-center justify-between p-3'>
                     <span className='font-medium text-light-black dark:text-white'>Addresses</span>

--- a/src/shared/components/header/AddressesDropdown.tsx
+++ b/src/shared/components/header/AddressesDropdown.tsx
@@ -66,7 +66,10 @@ export const AddressesDropdown = ({
     };
 
     return (
-        <div className='mx-4 w-full rounded-xl bg-white shadow-dropdown dark:bg-subtle-black' ref={dropdownRef}>
+        <div
+            className='mx-4 w-full rounded-xl bg-white shadow-dropdown dark:bg-subtle-black'
+            ref={dropdownRef}
+        >
             <div className='border-b border-solid border-b-theme-secondary-200 dark:border-b-theme-secondary-600'>
                 <div className=' flex items-center justify-between p-3'>
                     <span className='font-medium text-light-black dark:text-white'>Addresses</span>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[navbar] address dropdown no longer close on outside click](https://app.clickup.com/t/86drujuav)

## Summary

- Address dropdown now closes on outside click.

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/42afbbda-b297-4852-b22c-ef00040e87b0



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
