### PR TITLE
chore: only include utils in coverage

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
-import { mergeConfig } from 'vite';
 import { configDefaults, defineConfig } from 'vitest/config';
+
+import { mergeConfig } from 'vite';
 import viteConfig from './vite.config';
 
 export default defineConfig((env) => {
@@ -15,11 +16,12 @@ export default defineConfig((env) => {
                 setupFiles: ['./vitest.setup.ts'],
                 coverage: {
                     thresholds: {
-                        lines: 29.99,
-                        functions: 14.75,
-                        branches: 44.58,
-                        statements: 29.99,
+                        lines: 37.97,
+                        functions: 40,
+                        branches: 79.51,
+                        statements: 37.97,
                     },
+                    include: ['src/lib/utils/**'],
                 },
             },
         }),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

For the time being only `src/lib/utils` should be included for coverage until we extend this

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
