### PR TITLE
fix: align settings item icons

### DIFF
--- a/src/components/settings/SettingsOption.tsx
+++ b/src/components/settings/SettingsOption.tsx
@@ -54,8 +54,8 @@ export const SettingsOption = forwardRef(function RowLayout(
             aria-label={title}
             {...rest}
         >
-            <span className='flex w-full items-start gap-3'>
-                <span className='flex items-center justify-center overflow-hidden'>
+            <span className='flex w-full items-center gap-3'>
+                <span className='flex items-start justify-center overflow-hidden'>
                     <span
                         className={cn(
                             'h-5 w-5 text-theme-secondary-500 dark:text-theme-secondary-300',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86drv1nyr

![Screenshot from 2024-03-11 16-48-25](https://github.com/ArdentHQ/arkconnect-extension/assets/132887516/7e8e84da-6a80-400d-b550-a720cc20a932)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
