### PR TITLE
fix: onboarding page styles

### DIFF
--- a/src/components/settings/SetupPassword.tsx
+++ b/src/components/settings/SetupPassword.tsx
@@ -93,85 +93,90 @@ const SetupPassword = ({ formik }: Props) => {
     };
 
     return (
-        <div className='flex max-h-[450px] flex-col'>
+        <div className='flex min-h-[450px] flex-col'>
             <Heading $typeset='h3' fontWeight='bold' color='base' mb='8'>
                 Setup a Password
             </Heading>
             <Paragraph $typeset='headline' color='gray' mb='16'>
                 Create a password to access your wallet each time you use ARK Connect.
             </Paragraph>
-            <div className='flex flex-col gap-4'>
-                <PasswordInput
-                    name='password'
-                    variant={validation.password}
-                    labelText='Password'
-                    onChange={handlePasswordChange}
-                    value={values.password ?? ''}
-                    helperText={
-                        validation.password !== 'errorFree'
+            <div className='flex flex-col justify-between h-full'>
+                <div className='flex flex-col gap-4'>
+                    <PasswordInput
+                        name='password'
+                        variant={validation.password}
+                        labelText='Password'
+                        onChange={handlePasswordChange}
+                        value={values.password ?? ''}
+                        helperText={
+                            validation.password !== 'errorFree'
                             ? 'Requires at least 8 characters and one number'
                             : ''
-                    }
-                />
-                <PasswordInput
-                    name='passwordConfirm'
-                    value={values.passwordConfirm ?? ''}
-                    variant={validation.passwordConfirm}
-                    labelText='Confirm Password'
-                    onChange={handlePasswordConfirmChange}
-                    helperText={
-                        validation.passwordConfirm === 'destructive'
+                        }
+                        />
+                    <PasswordInput
+                        name='passwordConfirm'
+                        value={values.passwordConfirm ?? ''}
+                        variant={validation.passwordConfirm}
+                        labelText='Confirm Password'
+                        onChange={handlePasswordConfirmChange}
+                        helperText={
+                            validation.passwordConfirm === 'destructive'
                             ? 'Passwords do not match.'
                             : ''
-                    }
-                />
-            </div>
-            <div className='mt-auto flex'>
-                <Checkbox
-                    id='termsAndConditionsConfirmed'
-                    name='termsAndConditionsConfirmed'
-                    checked={values.termsAndConditionsConfirmed}
-                    onChange={handleTermsAndConditionsChange}
-                />
-                <div className='flex'>
-                    <Paragraph
-                        as='label'
-                        htmlFor='termsAndConditionsConfirmed'
-                        $typeset='body'
-                        color='base'
-                        fontWeight='medium'
-                    >
-                        I accept the{' '}
-                        <ExternalLink
-                            href={constants.TERMS_OF_SERVICE}
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            color='primary'
+                        }
+                        />
+                </div>
+                <div className='flex flex-col'>
+                    <div className='flex'>
+                        <Checkbox
+                            id='termsAndConditionsConfirmed'
+                            name='termsAndConditionsConfirmed'
+                            checked={values.termsAndConditionsConfirmed}
+                            onChange={handleTermsAndConditionsChange}
+                            />
+                        <div className='flex'>
+                            <Paragraph
+                                as='label'
+                                htmlFor='termsAndConditionsConfirmed'
+                                $typeset='body'
+                                color='base'
+                                fontWeight='medium'
+                                >
+                                I accept the{' '}
+                                <ExternalLink
+                                    href={constants.TERMS_OF_SERVICE}
+                                    target='_blank'
+                                    rel='noopener noreferrer'
+                                    color='primary'
+                                    >
+                                    Terms of Service
+                                </ExternalLink>{' '}
+                                and{' '}
+                                <ExternalLink
+                                    href={constants.PRIVACY_POLICY}
+                                    target='_blank'
+                                    rel='noopener noreferrer'
+                                    color='primary'
+                                    >
+                                    Privacy Policy
+                                </ExternalLink>
+                                .
+                            </Paragraph>
+                        </div>
+                    </div>
+
+                    <Button
+                        className='mt-6'
+                        variant='primary'
+                        disabled={!values.termsAndConditionsConfirmed || !isValid}
+                        onClick={submitForm}
                         >
-                            Terms of Service
-                        </ExternalLink>{' '}
-                        and{' '}
-                        <ExternalLink
-                            href={constants.PRIVACY_POLICY}
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            color='primary'
-                        >
-                            Privacy Policy
-                        </ExternalLink>
-                        .
-                    </Paragraph>
+                        Confirm
+                    </Button>
+                    
                 </div>
             </div>
-
-            <Button
-                className='mt-6'
-                variant='primary'
-                disabled={!values.termsAndConditionsConfirmed || !isValid}
-                onClick={submitForm}
-            >
-                Confirm
-            </Button>
         </div>
     );
 };

--- a/src/components/settings/SetupPassword.tsx
+++ b/src/components/settings/SetupPassword.tsx
@@ -100,7 +100,7 @@ const SetupPassword = ({ formik }: Props) => {
             <Paragraph $typeset='headline' color='gray' mb='16'>
                 Create a password to access your wallet each time you use ARK Connect.
             </Paragraph>
-            <div className='flex flex-col justify-between h-full'>
+            <div className='flex h-full flex-col justify-between'>
                 <div className='flex flex-col gap-4'>
                     <PasswordInput
                         name='password'
@@ -110,10 +110,10 @@ const SetupPassword = ({ formik }: Props) => {
                         value={values.password ?? ''}
                         helperText={
                             validation.password !== 'errorFree'
-                            ? 'Requires at least 8 characters and one number'
-                            : ''
+                                ? 'Requires at least 8 characters and one number'
+                                : ''
                         }
-                        />
+                    />
                     <PasswordInput
                         name='passwordConfirm'
                         value={values.passwordConfirm ?? ''}
@@ -122,10 +122,10 @@ const SetupPassword = ({ formik }: Props) => {
                         onChange={handlePasswordConfirmChange}
                         helperText={
                             validation.passwordConfirm === 'destructive'
-                            ? 'Passwords do not match.'
-                            : ''
+                                ? 'Passwords do not match.'
+                                : ''
                         }
-                        />
+                    />
                 </div>
                 <div className='flex flex-col'>
                     <div className='flex'>
@@ -134,7 +134,7 @@ const SetupPassword = ({ formik }: Props) => {
                             name='termsAndConditionsConfirmed'
                             checked={values.termsAndConditionsConfirmed}
                             onChange={handleTermsAndConditionsChange}
-                            />
+                        />
                         <div className='flex'>
                             <Paragraph
                                 as='label'
@@ -142,14 +142,14 @@ const SetupPassword = ({ formik }: Props) => {
                                 $typeset='body'
                                 color='base'
                                 fontWeight='medium'
-                                >
+                            >
                                 I accept the{' '}
                                 <ExternalLink
                                     href={constants.TERMS_OF_SERVICE}
                                     target='_blank'
                                     rel='noopener noreferrer'
                                     color='primary'
-                                    >
+                                >
                                     Terms of Service
                                 </ExternalLink>{' '}
                                 and{' '}
@@ -158,7 +158,7 @@ const SetupPassword = ({ formik }: Props) => {
                                     target='_blank'
                                     rel='noopener noreferrer'
                                     color='primary'
-                                    >
+                                >
                                     Privacy Policy
                                 </ExternalLink>
                                 .
@@ -171,10 +171,9 @@ const SetupPassword = ({ formik }: Props) => {
                         variant='primary'
                         disabled={!values.termsAndConditionsConfirmed || !isValid}
                         onClick={submitForm}
-                        >
+                    >
                         Confirm
                     </Button>
-                    
                 </div>
             </div>
         </div>

--- a/src/shared/components/loader/LoadingModal.tsx
+++ b/src/shared/components/loader/LoadingModal.tsx
@@ -11,7 +11,7 @@ const LoadingModal = () => {
     if (!isOpen) return null;
 
     return (
-        <div className='fixed left-0 top-0 z-10 flex h-screen w-full items-center justify-center bg-subtle-black dark:bg-light-black'>
+        <div className='fixed left-0 top-0 z-10 flex h-screen w-full items-center justify-center bg-subtle-white dark:bg-light-black'>
             <div className='flex flex-col items-center gap-6 px-4'>
                 {!isLoading ? (
                     <>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[various] multiple pages styled incorrectly](https://app.clickup.com/t/86drv1utr)

## Summary

- Margins in `Setup password` page have been updated.

<img width="364" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/0cece516-1435-4ff6-a7e9-1e6c1659f297">

- Background color for `Loading` pages on onboarding have been updated.

<img width="361" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/5afcd549-8707-4f79-8d65-2eb810b3eb5f">

- Loading pages for transactions have also been fixed.

<img width="362" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/947f13ce-216f-40e2-98ca-cec5437be603">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
