### PR TITLE
fix: align about ark copy icon

### DIFF
--- a/src/shared/components/button/RowLayout.tsx
+++ b/src/shared/components/button/RowLayout.tsx
@@ -151,7 +151,7 @@ export const RowLayout = forwardRef(function RowLayout(
                         {children && (
                             <span
                                 className={cn({
-                                    'mr-4': iconTrailing,
+                                    'mr-4 flex items-center': iconTrailing,
                                     'mr-0': !iconTrailing,
                                 })}
                             >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[extension] align about ark copy icon](https://app.clickup.com/t/86drv8q0w)

## Summary

- Ark about copy icon has now been fixed and is positioned correctly.

<img width="357" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/fb086236-1aa7-4a14-972b-2d2805fb427e">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
