### PR TITLE
fix: hide navbar on ledger pages

### DIFF
--- a/src/pages/ImportWithLedger.tsx
+++ b/src/pages/ImportWithLedger.tsx
@@ -102,7 +102,7 @@ const ImportWithLedger = () => {
 
     return (
         <div className='min-h-screen w-screen bg-subtle-white dark:bg-light-black'>
-            <Header />
+            <Header hideNavbar />
             <div className='flex min-h-screen w-full items-center justify-center pt-14'>
                 <div className='flex h-full items-center justify-center'>
                     <div className='w-[355px] rounded-lg bg-white py-6 dark:bg-subtle-black'>

--- a/src/shared/components/header/Header.tsx
+++ b/src/shared/components/header/Header.tsx
@@ -17,7 +17,7 @@ import { useProfileContext } from '@/lib/context/Profile';
 import { CopyAddress } from '@/components/wallet/CopyAddress';
 
 interface HeaderProps {
-    hideNavbar?: boolean
+    hideNavbar?: boolean;
 }
 
 export const Header = ({ hideNavbar = false }: HeaderProps) => {

--- a/src/shared/components/header/Header.tsx
+++ b/src/shared/components/header/Header.tsx
@@ -16,7 +16,11 @@ import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
 import { useProfileContext } from '@/lib/context/Profile';
 import { CopyAddress } from '@/components/wallet/CopyAddress';
 
-export const Header = () => {
+interface HeaderProps {
+    hideNavbar?: boolean
+}
+
+export const Header = ({ hideNavbar = false }: HeaderProps) => {
     const [openSettings, setOpenSettings] = useState(false);
 
     const isLocked = useAppSelector(selectLocked);
@@ -33,7 +37,7 @@ export const Header = () => {
 
     const [showAddressesDropdown, setShowAddressesDropdown] = useState<boolean>(false);
 
-    if (!primaryWallet || isLocked) {
+    if (!primaryWallet || isLocked || hideNavbar) {
         return (
             <HeaderWrapper className='px-4 py-[17px]' withShadow={!isOnboardingPage}>
                 <div className='logo flex items-center gap-2'>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[extension] remove navbar on Ledger import pages](https://app.clickup.com/t/86drv1nnf)

## Summary

- A new prop for header component has been added: `hideNavbar`. Which will render the alt version of our header if it is set as `True`.
- Navbar is now hidden in all the Ledger import pages.


https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/f0ca61cd-4a81-49ec-80ca-e6fcbf8f088d



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
