### PR TITLE
refactor: group class names for inputs 

### DIFF
--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -95,7 +95,7 @@
         @apply bg-theme-error-700;
     }
     .button-destructivePrimary:disabled {
-        @apply bg-theme-error-300 dark:bg-[rgba(240,68,56,0.20)];
+        @apply bg-theme-error-300 dark:bg-theme-error-800/20;
     }
     .button-destructivePrimary:focus {
         @apply shadow-[0_0_0_4px_theme-error-100] dark:shadow-[0_0_0_4px_#552D2A];

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -18,7 +18,7 @@
         @apply bg-theme-secondary-100 text-theme-secondary-400 dark:bg-theme-secondary-700;
     }
     .button-primary:focus {
-        @apply shadow-[0_0_0_4px_#E5F3ED] dark:shadow-[0_0_0_4px_rgba(74,205,151,0.24)];
+        @apply shadow-[0_0_0_4px_shadow-green] dark:shadow-[0_0_0_4px_rgba(74,205,151,0.24)];
     }
     .button-primary:focus-visible {
         @apply outline-2 outline-theme-primary-600;
@@ -32,7 +32,7 @@
         @apply bg-theme-primary-50 dark:bg-theme-secondary-800;
     }
     .button-secondary:focus-visible {
-        @apply shadow-[0_0_0_4px_#E5F3ED] outline-none dark:shadow-[0_0_0_4px_#2B3D35];
+        @apply shadow-[0_0_0_4px_shadow-green] outline-none dark:shadow-[0_0_0_4px_#2B3D35];
     }
     .button-secondary:disabled {
         @apply border-theme-secondary-100 bg-white text-theme-secondary-500 dark:border-theme-secondary-400 dark:bg-light-black dark:text-theme-secondary-300;

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -1,11 +1,11 @@
 @layer utilities {
     /** Text Area, Passphrase and Text Inputs **/
-    .textarea, 
+    .textarea,
     .text-input,
     .passphrase-primary,
     .passphrase-destructive,
     .passphrase-errorFree {
-        @apply border border-solid bg-white text-light-black focus:border focus:border-solid dark:bg-subtle-black dark:text-white
+        @apply border border-solid bg-white text-light-black focus:border focus:border-solid dark:bg-subtle-black dark:text-white;
     }
 
     .textarea-primary,
@@ -17,7 +17,7 @@
     .textarea-primary {
         @apply read-only:bg-white dark:read-only:bg-subtle-black;
     }
-    
+
     .textarea-destructive,
     .text-input-destructive,
     .passphrase-destructive {
@@ -43,7 +43,7 @@
     .radio-indicator,
     .checkbox-indicator,
     .toggle-switch-slider {
-        @apply absolute top-0
+        @apply absolute top-0;
     }
 
     .radio-indicator:hover,

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -145,7 +145,7 @@
     }
 
     [type='checkbox']:disabled:checked + .toggle-switch-slider {
-        @apply bg-[#9ADCC1] dark:bg-theme-primary-800;
+        @apply bg-theme-primary-200 dark:bg-theme-primary-800;
     }
 
     [type='checkbox']:disabled:checked + .toggle-switch-slider::before {

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -1,18 +1,37 @@
 @layer utilities {
-    /** Textarea **/
-    .textarea {
-        @apply border border-solid bg-white text-light-black focus:border focus:border-solid  dark:bg-subtle-black dark:text-white;
-    }
-    .textarea-primary {
-        @apply border-theme-secondary-400 read-only:bg-white focus:border-light-black disabled:bg-theme-secondary-100 dark:border-theme-secondary-500 read-only:dark:bg-subtle-black focus:dark:border-theme-secondary-300;
+    /** Text Area, Passphrase Input and Text Input **/
+    .textarea, 
+    .text-input,
+    .passphrase-primary,
+    .passphrase-destructive,
+    .passphrase-errorFree {
+        @apply border border-solid bg-white text-light-black focus:border focus:border-solid dark:bg-subtle-black dark:text-white
     }
 
-    .textarea-destructive {
+    .textarea-primary,
+    .text-input-primary,
+    .passphrase-primary {
+        @apply border-theme-secondary-400 focus:border-light-black disabled:bg-theme-secondary-100 dark:border-theme-secondary-500 focus:dark:border-theme-secondary-300;
+    }
+
+    .textarea-primary {
+        @apply read-only:bg-white dark:read-only:bg-subtle-black;
+    }
+    
+    .textarea-destructive,
+    .text-input-destructive,
+    .passphrase-destructive {
         @apply border-theme-error-300 focus:border-theme-error-600 focus:dark:border-theme-error-500;
     }
 
-    .textarea-errorFree {
+    .textarea-errorFree,
+    .text-input-errorFree,
+    .passphrase-errorFree {
         @apply border-theme-primary-700 focus:border-theme-primary-700 disabled:bg-theme-secondary-100 dark:border-theme-primary-650 focus:dark:border-theme-primary-650;
+    }
+
+    .text-input-destructive {
+        @apply border-theme-error-500;
     }
 
     /** Radio Input **/
@@ -114,39 +133,4 @@
         @apply bg-white;
     }
 
-    /** Text Input **/
-    .text-input {
-        @apply border border-solid bg-white text-light-black focus:border focus:border-solid dark:bg-subtle-black dark:text-white;
-    }
-
-    .text-input-primary {
-        @apply border-theme-secondary-400 focus:border-light-black disabled:bg-theme-secondary-100 dark:border-theme-secondary-500 focus:dark:border-theme-secondary-300;
-    }
-
-    .text-input-destructive {
-        @apply border-theme-error-500 focus:border-theme-error-600 focus:dark:border-theme-error-500;
-    }
-
-    .text-input-errorFree {
-        @apply border-theme-primary-700 focus:border-theme-primary-700  disabled:bg-theme-secondary-100 dark:border-theme-primary-650 focus:dark:border-theme-primary-650;
-    }
-
-    /** Passphrase Input **/
-    .passphrase-primary,
-    .passphrase-destructive,
-    .passphrase-errorFree {
-        @apply border border-solid bg-white text-light-black focus:border focus:border-solid dark:bg-subtle-black dark:text-white;
-    }
-
-    .passphrase-primary {
-        @apply border-theme-secondary-400 read-only:bg-white focus:border-light-black disabled:bg-theme-secondary-100 dark:read-only:bg-subtle-black dark:focus:border-theme-secondary-300;
-    }
-
-    .passphrase-destructive {
-        @apply border-theme-error-300 focus:border-theme-error-600 dark:focus:border-theme-error-500;
-    }
-
-    .passphrase-errorFree {
-        @apply border-theme-primary-700 focus:border-theme-primary-700 disabled:bg-theme-secondary-100 dark:border-theme-primary-650 dark:focus:border-theme-primary-650;
-    }
 }

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -1,5 +1,5 @@
 @layer utilities {
-    /** Text Area, Passphrase Input and Text Input **/
+    /** Text Area, Passphrase and Text Inputs **/
     .textarea, 
     .text-input,
     .passphrase-primary,
@@ -34,9 +34,32 @@
         @apply border-theme-error-500;
     }
 
+    /** Radio, Toggle switch and Checkbox Inputs **/
+    .radio-indicator,
+    .checkbox-indicator {
+        @apply h-5 w-5 border border-solid border-theme-primary-700 dark:border-theme-primary-600;
+    }
+
+    .radio-indicator,
+    .checkbox-indicator,
+    .toggle-switch-slider {
+        @apply absolute top-0
+    }
+
+    .radio-indicator:hover,
+    .checkbox-indicator:hover {
+        @apply bg-theme-primary-50 dark:hover:bg-theme-primary-900;
+    }
+
+    [type='radio']:disabled + .radio-indicator,
+    [type='checkbox']:disabled + .checkbox-indicator,
+    [type='checkbox']:disabled + .toggle-switch-slider {
+        @apply pointer-events-none;
+    }
+
     /** Radio Input **/
     .radio-indicator {
-        @apply transition-smoothEase absolute top-0 h-5 w-5 rounded-[10px] border border-solid border-theme-primary-700 after:absolute after:hidden after:content-[""] hover:bg-theme-primary-50 focus:shadow-[0_0_0_2px_light-green] focus:shadow-light-green active:shadow-[0_0_0_2px_light-green] dark:border-theme-primary-600 hover:dark:bg-theme-primary-900;
+        @apply transition-smoothEase rounded-[10px] after:absolute after:hidden after:content-[""] focus:shadow-[0_0_0_2px_light-green] focus:shadow-light-green active:shadow-[0_0_0_2px_light-green];
     }
 
     [type='radio']:checked + .radio-indicator::after {
@@ -48,12 +71,12 @@
     }
 
     [type='radio']:disabled + .radio-indicator {
-        @apply pointer-events-none border border-solid border-theme-secondary-300 bg-theme-secondary-100 dark:bg-black;
+        @apply border-theme-secondary-300 bg-theme-secondary-100 dark:bg-black;
     }
 
     /** Checkbox Input **/
     .checkbox-indicator {
-        @apply absolute top-0 h-5 w-5 rounded-md border border-solid border-theme-primary-700 bg-transparent hover:bg-theme-primary-50  dark:border-theme-primary-600 dark:hover:bg-theme-primary-900;
+        @apply rounded-md bg-transparent;
     }
 
     .checkbox-indicator::after {
@@ -98,7 +121,7 @@
 
     /** Toggle switch **/
     .toggle-switch-slider {
-        @apply absolute bottom-0 left-0 right-0 top-0 z-1 cursor-pointer rounded-xl bg-theme-secondary-200 duration-[0.4s] hover:bg-theme-primary-700 group-hover:bg-theme-primary-50 dark:bg-theme-secondary-600 dark:hover:bg-theme-primary-650 dark:group-hover:bg-theme-primary-900;
+        @apply bottom-0 left-0 right-0 z-1 cursor-pointer rounded-xl bg-theme-secondary-200 duration-[0.4s] hover:bg-theme-primary-700 group-hover:bg-theme-primary-50 dark:bg-theme-secondary-600 dark:hover:bg-theme-primary-650 dark:group-hover:bg-theme-primary-900;
     }
 
     .toggle-switch-slider::before {
@@ -111,10 +134,6 @@
 
     [type='checkbox']:checked + .toggle-switch-slider::before {
         @apply translate-x-[14px] transform;
-    }
-
-    [type='checkbox']:disabled + .toggle-switch-slider {
-        @apply pointer-events-none;
     }
 
     [type='checkbox']:disabled:not(:checked) + .toggle-switch-slider {
@@ -132,5 +151,4 @@
     [type='checkbox']:disabled:checked + .toggle-switch-slider::before {
         @apply bg-white;
     }
-
 }

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -71,4 +71,5 @@
 
     /* light green */
     --theme-color-light-green: 229 255 244; /* #E5FFF4 */
+    --theme-color-shadow-green: 229 243 237; /* #E5F3ED */
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -142,6 +142,7 @@ export default {
 
             // shadow
             'light-green': 'rgb(var(--theme-color-light-green) / <alpha-value>)',
+            'shadow-green': 'rgb(var(--theme-color-shadow-green) / <alpha-value>)',
         },
     },
     plugins: [],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[style] final checks for duplication once everything is moved over](https://app.clickup.com/t/86drrz624)

## Summary

- Class names for toggle switch, radio, checkbox inputs have been grouped together. Same as the ones for passphrase, textarea and text inputs.
- New `shadow-green` custom color added to our palette.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
