### PR TITLE
fix: ledger error component styling

### DIFF
--- a/src/pages/ImportWithLedger.tsx
+++ b/src/pages/ImportWithLedger.tsx
@@ -115,8 +115,8 @@ const ImportWithLedger = () => {
                     </div>
                 </div>
                 {error && (
-                    <div className=' fixed bottom-0 left-0 z-20 flex w-full items-center justify-center border border-solid border-t-theme-error-300 bg-theme-error-500 px-2 dark:border-t-theme-error-500 dark:bg-[rgba(255,86,74,0.26)]'>
-                        <div className='flex items-center gap-6'>
+                    <div className='fixed bottom-0 left-0 z-20 flex w-full items-center justify-center border-t border-t-theme-error-300 bg-theme-error-50 px-2 dark:border-t-theme-error-500 dark:bg-[rgba(255,86,74,0.26)] py-2'>
+                        <div className='flex items-center gap-4 h-8'>
                             <div className='flex items-center gap-2'>
                                 <Icon
                                     icon='information-circle'

--- a/src/pages/ImportWithLedger.tsx
+++ b/src/pages/ImportWithLedger.tsx
@@ -115,8 +115,8 @@ const ImportWithLedger = () => {
                     </div>
                 </div>
                 {error && (
-                    <div className='fixed bottom-0 left-0 z-20 flex w-full items-center justify-center border-t border-t-theme-error-300 bg-theme-error-50 px-2 dark:border-t-theme-error-500 dark:bg-[rgba(255,86,74,0.26)] py-2'>
-                        <div className='flex items-center gap-4 h-8'>
+                    <div className='fixed bottom-0 left-0 z-20 flex w-full items-center justify-center border-t border-t-theme-error-300 bg-theme-error-50 px-2 py-2 dark:border-t-theme-error-500 dark:bg-[rgba(255,86,74,0.26)]'>
+                        <div className='flex h-8 items-center gap-4'>
                             <div className='flex items-center gap-2'>
                                 <Icon
                                     icon='information-circle'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[extension] improve error styling on Ledger pages](https://app.clickup.com/t/86drwd1tr)

## Summary

- Borders for error component have been fixed. Same as the height of its content and the paddings.
- Colors have been fixed to match the design.

## Screenshots

- Light mode:

<img width="641" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/d7b69e19-72c9-441a-8262-452e5964addc">


- Dark mode:

<img width="635" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/c6f7305c-1029-49f5-9d19-8aeead42737e">


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
