### PR TITLE
refactor: recheck ledger list on clicking back button

### DIFF
--- a/src/components/steps/StepsNavigation.tsx
+++ b/src/components/steps/StepsNavigation.tsx
@@ -41,7 +41,7 @@ const StepsNavigation = <T extends Record<string, any>>({
             navigate(-1);
             onStepChange?.(-1);
         }
-        if(steps[currentStep].onClickBack) {
+        if (steps[currentStep].onClickBack) {
             steps[currentStep].onClickBack?.();
         }
     };

--- a/src/components/steps/StepsNavigation.tsx
+++ b/src/components/steps/StepsNavigation.tsx
@@ -9,6 +9,7 @@ import { ArrowButton } from '@/shared/components';
 export type Step = {
     component: ComponentType<any>;
     containerPaddingX?: '0' | '24';
+    onClickBack?: () => void;
 };
 
 interface StepNavigationProps<T> extends React.HTMLAttributes<HTMLDivElement> {
@@ -39,6 +40,9 @@ const StepsNavigation = <T extends Record<string, any>>({
         } else {
             navigate(-1);
             onStepChange?.(-1);
+        }
+        if(steps[currentStep].onClickBack !== undefined) {
+            steps[currentStep].onClickBack?.();
         }
     };
 

--- a/src/components/steps/StepsNavigation.tsx
+++ b/src/components/steps/StepsNavigation.tsx
@@ -41,7 +41,7 @@ const StepsNavigation = <T extends Record<string, any>>({
             navigate(-1);
             onStepChange?.(-1);
         }
-        if(steps[currentStep].onClickBack !== undefined) {
+        if(steps[currentStep].onClickBack) {
             steps[currentStep].onClickBack?.();
         }
     };

--- a/src/pages/ImportWithLedger.tsx
+++ b/src/pages/ImportWithLedger.tsx
@@ -30,13 +30,8 @@ const ImportWithLedger = () => {
     const network = useActiveNetwork();
     const { profile, initProfile } = useProfileContext();
     const { defaultCurrency } = useLocaleCurrency();
-    const { 
-        error, 
-        removeErrors,
-        resetConnectionState,
-        disconnect,
-        abortConnectionRetry,
-    } = useLedgerContext();
+    const { error, removeErrors, resetConnectionState, disconnect, abortConnectionRetry } =
+        useLedgerContext();
     const { onError } = useErrorHandlerContext();
 
     const handleClickBack = () => {
@@ -46,7 +41,7 @@ const ImportWithLedger = () => {
     };
 
     const [steps, setSteps] = useState<Step[]>([
-        { component: LedgerConnectionStep, containerPaddingX: '24'},
+        { component: LedgerConnectionStep, containerPaddingX: '24' },
         { component: ImportWallets, onClickBack: handleClickBack },
     ]);
     const { env } = useEnvironmentContext();

--- a/src/pages/ImportWithLedger.tsx
+++ b/src/pages/ImportWithLedger.tsx
@@ -30,11 +30,24 @@ const ImportWithLedger = () => {
     const network = useActiveNetwork();
     const { profile, initProfile } = useProfileContext();
     const { defaultCurrency } = useLocaleCurrency();
-    const { error, removeErrors } = useLedgerContext();
+    const { 
+        error, 
+        removeErrors,
+        resetConnectionState,
+        disconnect,
+        abortConnectionRetry,
+    } = useLedgerContext();
     const { onError } = useErrorHandlerContext();
+
+    const handleClickBack = () => {
+        disconnect();
+        abortConnectionRetry();
+        resetConnectionState();
+    };
+
     const [steps, setSteps] = useState<Step[]>([
-        { component: LedgerConnectionStep, containerPaddingX: '24' },
-        { component: ImportWallets },
+        { component: LedgerConnectionStep, containerPaddingX: '24'},
+        { component: ImportWallets, onClickBack: handleClickBack },
     ]);
     const { env } = useEnvironmentContext();
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[ledger] recheck checklist if user selects "back" on address selection](https://app.clickup.com/t/86drwt795)

## Summary

- Step navigation now supports `onClickBack` prop in case we want a custom action to happen when we click `back` button.
- If we click `back` on ledger selection page, we now re-run the checks for connection.



https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/d0498f22-55c8-4c71-a947-a9aebd64827e



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
