### PR TITLE
fix: move ledger tx hooks outside of conditionals

### DIFF
--- a/src/components/ledger/ApproveWithLedger.tsx
+++ b/src/components/ledger/ApproveWithLedger.tsx
@@ -43,25 +43,27 @@ const ApproveWithLedger = ({
         vote = null,
         unvote = null;
 
+    const {
+        values: { fee: transactionFee, total: transactionTotal, hasHigherCustomFee },
+    } = useSendTransferForm(wallet, {
+        session,
+        amount,
+        receiverAddress,
+    });
+
+    const {
+        values: { fee: voteFee, vote: voteAction, unvote: unvoteAction },
+    } = useVoteForm(wallet, state);
+
     if (
         actionType === ApproveActionType.VOTE ||
         actionType === ApproveActionType.UNVOTE ||
         actionType === ApproveActionType.SWITCH_VOTE
     ) {
-        const {
-            values: { fee: voteFee, vote: voteAction, unvote: unvoteAction },
-        } = useVoteForm(wallet, state);
         fee = voteFee;
         vote = voteAction;
         unvote = unvoteAction;
     } else if (actionType === ApproveActionType.TRANSACTION) {
-        const {
-            values: { fee: transactionFee, total: transactionTotal },
-        } = useSendTransferForm(wallet, {
-            session,
-            amount,
-            receiverAddress,
-        });
         fee = transactionFee;
         total = transactionTotal;
     }
@@ -137,6 +139,7 @@ const ApproveWithLedger = ({
                             fee={fee}
                             total={total}
                             wallet={wallet}
+                            hasHigherCustomFee={hasHigherCustomFee}
                         />
                     )}
                     {actionType === ApproveActionType.SIGNATURE && (


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The hooks need to be at the top level and they should be avoided inside conditions loops etc. https://legacy.reactjs.org/docs/hooks-rules.html#:~:text=Don't%20call%20Hooks%20inside,each%20time%20a%20component%20renders.

Spotted it while fixing build errors in https://github.com/ArdentHQ/arkconnect-extension/pull/184

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
