### PR TITLE
fix: set default value for amount in ledger transactions

### DIFF
--- a/src/lib/hooks/useSendTransferForm.ts
+++ b/src/lib/hooks/useSendTransferForm.ts
@@ -193,7 +193,9 @@ export const useSendTransferForm = (
                     hasHigherCustomFee:
                         request.customFee && request.customFee > averageFee ? averageFee : null,
                     mnemonic: passphrase?.join(' ') || '',
-                    total: BigNumber.make(fee).plus(request.amount ?? 0).toHuman(),
+                    total: BigNumber.make(fee)
+                        .plus(request.amount ?? 0)
+                        .toHuman(),
                     recipients: [
                         {
                             address: request.receiverAddress,

--- a/src/lib/hooks/useSendTransferForm.ts
+++ b/src/lib/hooks/useSendTransferForm.ts
@@ -193,7 +193,7 @@ export const useSendTransferForm = (
                     hasHigherCustomFee:
                         request.customFee && request.customFee > averageFee ? averageFee : null,
                     mnemonic: passphrase?.join(' ') || '',
-                    total: BigNumber.make(fee).plus(request.amount).toHuman(),
+                    total: BigNumber.make(fee).plus(request.amount ?? 0).toHuman(),
                     recipients: [
                         {
                             address: request.receiverAddress,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[extension] cannot sign message with ledger](https://app.clickup.com/t/86dt25048)

## Summary

- `Amount` was being passed as `undefined` from `request` object when an action didn't include any numeric amount (like in Signing).

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
