### PR TITLE
refactor: testnet icon in select Ledger address

### DIFF
--- a/src/components/ledger/ImportWallets.tsx
+++ b/src/components/ledger/ImportWallets.tsx
@@ -122,11 +122,11 @@ const ImportWallets = ({ goToNextStep, formik }: Props) => {
 
     return (
         <div>
-            <div className='flex flex-row gap-2 items-center mb-2 pl-6'>
+            <div className='mb-2 flex flex-row items-center gap-2 pl-6'>
                 <Heading level={3}>
                     {t('PAGES.IMPORT_WITH_LEDGER.SELECT_ADDRESSES_TO_IMPORT')}
                 </Heading>
-                {network.name() === WalletNetwork.DEVNET ? <TestnetIcon/> : null}
+                {network.name() === WalletNetwork.DEVNET ? <TestnetIcon /> : null}
             </div>
             <p className='typeset-body mb-6 px-6 text-theme-secondary-500 dark:text-theme-secondary-300'>
                 {t('PAGES.IMPORT_WITH_LEDGER.MULTIPLE_ADDRESSES_CAN_BE_IMPORTED')}

--- a/src/components/ledger/ImportWallets.tsx
+++ b/src/components/ledger/ImportWallets.tsx
@@ -13,8 +13,9 @@ import { ImportWithLedger } from '@/pages/ImportWithLedger';
 import { HandleLoadingState } from '@/shared/components/handleStates/HandleLoadingState';
 import useOnError from '@/lib/hooks';
 import { getNetworkCurrency } from '@/lib/utils/getActiveCoin';
-import { AddressBalance } from '@/components/wallet/address/Address.blocks';
+import { AddressBalance, TestnetIcon } from '@/components/wallet/address/Address.blocks';
 import { handleSubmitKeyAction } from '@/lib/utils/handleKeyAction';
+import { WalletNetwork } from '@/lib/store/wallet';
 
 type Props = {
     goToNextStep: () => void;
@@ -121,9 +122,12 @@ const ImportWallets = ({ goToNextStep, formik }: Props) => {
 
     return (
         <div>
-            <Heading level={3} className='mb-2 px-6'>
-                {t('PAGES.IMPORT_WITH_LEDGER.SELECT_ADDRESSES_TO_IMPORT')}
-            </Heading>
+            <div className='flex flex-row gap-2 items-center mb-2 pl-6'>
+                <Heading level={3}>
+                    {t('PAGES.IMPORT_WITH_LEDGER.SELECT_ADDRESSES_TO_IMPORT')}
+                </Heading>
+                {network.name() === WalletNetwork.DEVNET ? <TestnetIcon/> : null}
+            </div>
             <p className='typeset-body mb-6 px-6 text-theme-secondary-500 dark:text-theme-secondary-300'>
                 {t('PAGES.IMPORT_WITH_LEDGER.MULTIPLE_ADDRESSES_CAN_BE_IMPORTED')}
             </p>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[ledger] select address header should contain Testnet icon](https://app.clickup.com/t/86dt23g5e)

## Summary

- Testnet icon is now displayed in select address header.

## Screenshots

- Mainnet:

<img width="459" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/6596d6c9-9c72-47ea-87f2-d0aadfdc90ed">

- Testnet:

<img width="427" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/d39f70ac-b627-4087-ba4d-4b80a06b9701">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
