### PR TITLE
fix: tooltips in Ledger approval page

### DIFF
--- a/src/components/approve/ActionBody.blocks.tsx
+++ b/src/components/approve/ActionBody.blocks.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Address } from '../wallet/address/Address.blocks';
-import { ActionDetailsFiatValue, ActionDetailsRow, ActionDetailsValue } from './ActionDetails';
+import { ActionDetailsFiatValue, ActionDetailsRow } from './ActionDetails';
+import { ActionDetailsValue } from './ActionDetailsValue';
 import { Icon, Tooltip } from '@/shared/components';
 import trimAddress from '@/lib/utils/trimAddress';
 import useClipboard from '@/lib/hooks/useClipboard';

--- a/src/components/approve/ActionDetails.tsx
+++ b/src/components/approve/ActionDetails.tsx
@@ -36,10 +36,6 @@ export const ActionDetailsFiatValue = ({ children }: { children: React.ReactNode
     );
 };
 
-export const ActionDetailsValue = ({ children }: { children: React.ReactNode }) => {
-    return <div className='text-sm font-medium text-light-black dark:text-white'>{children}</div>;
-};
-
 const ActionDetails = ({
     children,
     maxHeight,

--- a/src/components/approve/ActionDetailsValue.tsx
+++ b/src/components/approve/ActionDetailsValue.tsx
@@ -1,0 +1,13 @@
+import { forwardRef } from 'react';
+
+export const ActionDetailsValue = forwardRef<HTMLDivElement, { children: React.ReactNode }>(
+    ({ children }, ref) => {
+      return (
+        <div ref={ref} className='text-sm font-medium text-light-black dark:text-white'>
+          {children}
+        </div>
+      );
+    }
+);
+
+ActionDetailsValue.displayName = 'ActionDetailsValue';

--- a/src/components/approve/ActionDetailsValue.tsx
+++ b/src/components/approve/ActionDetailsValue.tsx
@@ -2,12 +2,12 @@ import { forwardRef } from 'react';
 
 export const ActionDetailsValue = forwardRef<HTMLDivElement, { children: React.ReactNode }>(
     ({ children }, ref) => {
-      return (
-        <div ref={ref} className='text-sm font-medium text-light-black dark:text-white'>
-          {children}
-        </div>
-      );
-    }
+        return (
+            <div ref={ref} className='text-sm font-medium text-light-black dark:text-white'>
+                {children}
+            </div>
+        );
+    },
 );
 
 ActionDetailsValue.displayName = 'ActionDetailsValue';


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[extension] tooltip not working on Ledger approval page](https://app.clickup.com/t/86dt2k5cm)

## Summary

- `ActionDetailsValue` component has been refactored. It now forwards the ref from the tooltips in case it is a child component.
- Tooltips are now being correctly rendered in Ledger approval pages.

<img width="367" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/9e6cce5e-0119-41d0-a295-69b60af18f5e">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
