### PR TITLE
fix: remove twMerge from text input class names

### DIFF
--- a/src/shared/components/input/Input.tsx
+++ b/src/shared/components/input/Input.tsx
@@ -1,6 +1,5 @@
 import { MutableRefObject } from 'react';
 import cn from 'classnames';
-import { twMerge } from 'tailwind-merge';
 
 type InputProps = React.ComponentPropsWithRef<'input'> & {
     trailing?: React.ReactNode;
@@ -35,7 +34,7 @@ export const Input = ({
 
             <div className='relative flex w-full items-center'>
                 <input
-                    className={twMerge(
+                    className={
                         cn(
                             'transition-smoothEase text-input max-h-13 w-full rounded-lg border-none px-3 py-4 text-base font-normal outline-none placeholder:text-theme-secondary-400 disabled:pointer-events-none disabled:cursor-not-allowed',
                             {
@@ -43,9 +42,9 @@ export const Input = ({
                                 'text-input-destructive': variant === 'destructive',
                                 'text-input-errorFree': variant === 'errorFree',
                             },
-                        ),
-                        className,
-                    )}
+                            className
+                        )
+                    }
                     id={id}
                     ref={innerRef}
                     {...rest}

--- a/src/shared/components/input/Input.tsx
+++ b/src/shared/components/input/Input.tsx
@@ -34,17 +34,15 @@ export const Input = ({
 
             <div className='relative flex w-full items-center'>
                 <input
-                    className={
-                        cn(
-                            'transition-smoothEase text-input max-h-13 w-full rounded-lg border-none px-3 py-4 text-base font-normal outline-none placeholder:text-theme-secondary-400 disabled:pointer-events-none disabled:cursor-not-allowed',
-                            {
-                                'text-input-primary': variant === 'primary',
-                                'text-input-destructive': variant === 'destructive',
-                                'text-input-errorFree': variant === 'errorFree',
-                            },
-                            className
-                        )
-                    }
+                    className={cn(
+                        'transition-smoothEase text-input max-h-13 w-full rounded-lg border-none px-3 py-4 text-base font-normal outline-none placeholder:text-theme-secondary-400 disabled:pointer-events-none disabled:cursor-not-allowed',
+                        {
+                            'text-input-primary': variant === 'primary',
+                            'text-input-destructive': variant === 'destructive',
+                            'text-input-errorFree': variant === 'errorFree',
+                        },
+                        className,
+                    )}
                     id={id}
                     ref={innerRef}
                     {...rest}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[dark] input fields are white](https://app.clickup.com/t/86dt2n2mr) & [[general] input fields missing border](https://app.clickup.com/t/86dt2mm4c)

## Summary

- `twMerge` is being removed from classnames in text inputs.

<img width="363" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/040a7e46-8245-4f5a-a6df-42c53471b000">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
