### PR TITLE
fix: text alignment for modal title

### DIFF
--- a/src/components/connect/ErrorModal.tsx
+++ b/src/components/connect/ErrorModal.tsx
@@ -16,7 +16,7 @@ const ErrorModal = ({ error, onClose }: Props) => {
                     <SmallWarningIcon />
 
                     <div>
-                        <Heading level={3} className='mb-2'>
+                        <Heading level={3} className='mb-2 text-center'>
                             {errorTitleParser(error)}
                         </Heading>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[extension] text alignment in error modals](https://app.clickup.com/t/86dt316c1)

## Summary

- Modal title alignment has been fixed and it is now correctly centered.

<img width="357" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/898a3718-7e4a-47dc-bb64-b8a60aea7df2">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
