### PR TITLE
refactor: connection modal styling

### DIFF
--- a/src/components/approve/ActionBody.blocks.tsx
+++ b/src/components/approve/ActionBody.blocks.tsx
@@ -114,7 +114,7 @@ export const ActionAddressRow = ({ label, address }: { label: string; address: s
                 address={address}
                 tooltipPlacement='bottom-end'
                 length={10}
-                className='leading-5 font-medium text-light-black dark:text-white'
+                className='font-medium leading-5 text-light-black dark:text-white'
             />
         </ActionDetailsRow>
     );

--- a/src/components/approve/ActionBody.blocks.tsx
+++ b/src/components/approve/ActionBody.blocks.tsx
@@ -114,7 +114,7 @@ export const ActionAddressRow = ({ label, address }: { label: string; address: s
                 address={address}
                 tooltipPlacement='bottom-end'
                 length={10}
-                classNames='leading-5 font-medium text-light-black dark:text-white'
+                className='leading-5 font-medium text-light-black dark:text-white'
             />
         </ActionDetailsRow>
     );

--- a/src/components/ledger/ImportWallets.tsx
+++ b/src/components/ledger/ImportWallets.tsx
@@ -13,8 +13,9 @@ import { ImportWithLedger } from '@/pages/ImportWithLedger';
 import { HandleLoadingState } from '@/shared/components/handleStates/HandleLoadingState';
 import useOnError from '@/lib/hooks';
 import { getNetworkCurrency } from '@/lib/utils/getActiveCoin';
-import { AddressBalance } from '@/components/wallet/address/Address.blocks';
+import { AddressBalance, TestnetIcon } from '@/components/wallet/address/Address.blocks';
 import { handleSubmitKeyAction } from '@/lib/utils/handleKeyAction';
+import { WalletNetwork } from '@/lib/store/wallet';
 
 type Props = {
     goToNextStep: () => void;
@@ -121,9 +122,12 @@ const ImportWallets = ({ goToNextStep, formik }: Props) => {
 
     return (
         <div>
-            <Heading level={3} className='mb-2 px-6'>
-                {t('PAGES.IMPORT_WITH_LEDGER.SELECT_ADDRESSES_TO_IMPORT')}
-            </Heading>
+            <div className='mb-2 flex flex-row items-center gap-2 pl-6'>
+                <Heading level={3}>
+                    {t('PAGES.IMPORT_WITH_LEDGER.SELECT_ADDRESSES_TO_IMPORT')}
+                </Heading>
+                {network.name() === WalletNetwork.DEVNET ? <TestnetIcon /> : null}
+            </div>
             <p className='typeset-body mb-6 px-6 text-theme-secondary-500 dark:text-theme-secondary-300'>
                 {t('PAGES.IMPORT_WITH_LEDGER.MULTIPLE_ADDRESSES_CAN_BE_IMPORTED')}
             </p>

--- a/src/components/wallet/ConnectedAddress.tsx
+++ b/src/components/wallet/ConnectedAddress.tsx
@@ -50,13 +50,13 @@ const ConnectedAddress = ({ connectedTo, wallet, logo, onDisconnect }: Propertie
 
 const AddressRow = ({ address, logo }: { address: Contracts.IReadWriteWallet; logo: string }) => {
     return (
-        <div className='flex gap-3 rounded-2xl border border-solid border-theme-primary-600 bg-theme-primary-50 p-4 shadow-light dark:border-theme-primary-650 dark:bg-theme-primary-650/15'>
+        <div className='flex gap-3 rounded-2xl border border-solid border-theme-secondary-200 bg-theme-secondary-50 p-4 shadow-light dark:border-theme-secondary-700 dark:bg-subtle-black'>
             <ConnectionLogoImage
                 appLogo={logo}
                 appName='Connected'
                 roundCorners
                 withBorder
-                className='h-10 w-10 border-theme-primary-200 dark:border-[#296148]'
+                className='h-10 w-10 border-theme-secondary-200 dark:border-theme-secondary-700'
             />
             <div className='flex flex-col gap-1'>
                 <div className='flex items-center gap-1.5'>
@@ -68,11 +68,12 @@ const AddressRow = ({ address, logo }: { address: Contracts.IReadWriteWallet; lo
                 </div>
 
                 <div className='flex items-center gap-1.5 text-theme-secondary-500 dark:text-theme-secondary-300'>
-                    <Address address={address.address()} />
+                    <Address address={address.address()} className='hover:text-light-black dark:hover:text-white' />
                     <div className='leading-[18px]'>•</div>
                     <AddressBalance
                         balance={address.balance()}
                         currency={getNetworkCurrency(address.network())}
+                        className='hover:text-light-black dark:hover:text-white'
                     />
                 </div>
             </div>

--- a/src/components/wallet/address/Address.blocks.tsx
+++ b/src/components/wallet/address/Address.blocks.tsx
@@ -66,12 +66,12 @@ export const Address = ({
     address,
     length = 10,
     tooltipPlacement = 'top',
-    classNames,
+    className,
 }: {
     address: string;
     length?: number;
     tooltipPlacement?: TippyProps['placement'];
-    classNames?: string;
+    className?: string;
 }) => {
     return (
         <div>
@@ -79,7 +79,7 @@ export const Address = ({
                 <p
                     className={twMerge(
                         'max-w-44 cursor-pointer text-sm font-normal leading-[17.5px] text-theme-secondary-500 underline-offset-2 hover:underline dark:text-theme-secondary-300',
-                        classNames,
+                        className,
                     )}
                 >
                     {trimAddress(address, length)}
@@ -116,14 +116,16 @@ export const AddressBalance = ({
     balance,
     currency,
     maxDigits = 5,
+    className,
 }: {
     balance: number;
     currency: string;
     maxDigits?: number;
+    className?: string;
 }) => {
     return (
         <div className='text-theme-secondary-500 dark:text-theme-primary-300'>
-            <p className='typeset-body cursor-pointer text-theme-secondary-500 dark:text-theme-secondary-300'>
+            <p className={twMerge('typeset-body cursor-pointer text-theme-secondary-500 dark:text-theme-secondary-300', className)}>
                 <Amount
                     value={balance}
                     ticker={currency}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[connections] change styling of connection modal](https://app.clickup.com/t/86dt30jwx)

## Summary

- Styling for connection modal has been updated to match the designs.

## Screenshots

- Light mode:
<img width="365" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/f8bafbe2-e633-4557-b2d3-5a8b11ce9b25">


- Dark mode:

<img width="356" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/9318145a-e0bb-4ca0-a370-dd2e8108676f">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
