### PR TITLE
fix: default styles for connection logos on error

### DIFF
--- a/src/components/connections/ConnectionLogoImage.tsx
+++ b/src/components/connections/ConnectionLogoImage.tsx
@@ -36,7 +36,7 @@ const ConnectionLogoImage = ({
                                     {
                                         'border-[10px] border-solid': withBorder,
                                         'border-theme-secondary-50 dark:border-light-black':
-                                            withBorder && (loading && !data || error),
+                                            withBorder && ((loading && !data) || error),
                                         'rounded-full': roundCorners,
                                     },
                                 ),

--- a/src/components/connections/ConnectionLogoImage.tsx
+++ b/src/components/connections/ConnectionLogoImage.tsx
@@ -2,7 +2,6 @@ import { twMerge } from 'tailwind-merge';
 import cn from 'classnames';
 import Color from 'color-thief-react';
 import { Icon } from '@/shared/components';
-
 import { ThemeMode } from '@/lib/store/ui';
 import useThemeMode from '@/lib/hooks/useThemeMode';
 import { convertHexToRGBA } from '@/lib/utils/convertHexToRgba';
@@ -26,7 +25,7 @@ const ConnectionLogoImage = ({
     if (appLogo) {
         return (
             <Color src={appLogo} crossOrigin='anonymous' format='hex'>
-                {({ loading, data }) => {
+                {({ loading, data, error }) => {
                     const color = loading ? '' : convertHexToRGBA(data ?? '', '0.20');
 
                     return (
@@ -36,8 +35,8 @@ const ConnectionLogoImage = ({
                                     'h-5 w-5 flex-shrink-0 overflow-hidden bg-white dark:bg-light-black',
                                     {
                                         'border-[10px] border-solid': withBorder,
-                                        'border-white dark:border-light-black':
-                                            withBorder && loading && !data,
+                                        'border-theme-secondary-50 dark:border-light-black':
+                                            withBorder && (loading && !data || error),
                                         'rounded-full': roundCorners,
                                     },
                                 ),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[extension] connected apps background colour issue firefox](https://app.clickup.com/t/86dt7cwf7)

## Summary

- `color-thief-react` and other packages such as `react-color-extractor` were having CORS policy issues when trying to inspect the logo. This caused the image's backgrounds to go fully black on Firefox.
<img width="1028" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/039fc839-107d-4649-b963-8f3b82d9d306">
- Default styles have been set in case errors are returned when inspecting the favicon.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->


## Screenshots

- Light mode:

<img width="363" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/e3d32d47-b0d4-4d2d-be1e-4cd2bb01cce3">


- Dark mode:

<img width="351" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/3e68f848-fc4b-41a8-b6d0-1b4b4396a857">


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
