### PR TITLE
refactor: truncation for memo field

### DIFF
--- a/src/components/approve/ActionBody.blocks.tsx
+++ b/src/components/approve/ActionBody.blocks.tsx
@@ -15,7 +15,13 @@ interface ActionBodyRowProps {
     className?: string;
 }
 
-export const ActionBodyRow = ({ label, below, value, tooltipContent, className }: ActionBodyRowProps) => (
+export const ActionBodyRow = ({
+    label,
+    below,
+    value,
+    tooltipContent,
+    className,
+}: ActionBodyRowProps) => (
     <ActionDetailsRow label={label} below={below}>
         {tooltipContent ? (
             <Tooltip content={tooltipContent} placement='bottom-end'>

--- a/src/components/approve/ActionBody.tsx
+++ b/src/components/approve/ActionBody.tsx
@@ -79,7 +79,14 @@ export const ActionBody = ({
             )}
 
             {receiver && <ActionAddressRow label={t('COMMON.RECEIVER')} address={receiver} />}
-            {memo && <ActionBodyRow label={t('COMMON.MEMO')} value={memo} className='pl-20 truncate' tooltipContent={memo} />}
+            {memo && (
+                <ActionBodyRow
+                    label={t('COMMON.MEMO')}
+                    value={memo}
+                    className='truncate pl-20'
+                    tooltipContent={memo}
+                />
+            )}
 
             <ActionAmountRow
                 label={

--- a/src/components/approve/ActionDetailsValue.tsx
+++ b/src/components/approve/ActionDetailsValue.tsx
@@ -1,14 +1,18 @@
 import { forwardRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
-export const ActionDetailsValue = forwardRef<HTMLDivElement, { children: React.ReactNode, className?: string }>(
-    ({ children, className }, ref) => {
-        return (
-            <div ref={ref} className={twMerge('text-sm font-medium text-light-black dark:text-white', className)}>
-                {children}
-            </div>
-        );
-    },
-);
+export const ActionDetailsValue = forwardRef<
+    HTMLDivElement,
+    { children: React.ReactNode; className?: string }
+>(({ children, className }, ref) => {
+    return (
+        <div
+            ref={ref}
+            className={twMerge('text-sm font-medium text-light-black dark:text-white', className)}
+        >
+            {children}
+        </div>
+    );
+});
 
 ActionDetailsValue.displayName = 'ActionDetailsValue';


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] add breakword/truncation to memo](https://app.clickup.com/t/86dtayj82)

## Summary

- We now support custom class names in `ActionDetailsValue` component.
- "Memo" field is now truncated and the full memo appears on a hover tooltip.

<img width="373" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/19bba1ed-ba79-4358-aeae-373c33c1f566">

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
