### PR TITLE
refactor: hide fiat values in devnet

### DIFF
--- a/src/components/transaction/Transaction.blocks.tsx
+++ b/src/components/transaction/Transaction.blocks.tsx
@@ -133,13 +133,11 @@ export const TransactionAmount = ({
                 type={type}
                 selfAmount={selfAmount}
             />
-            {
-                !isDevnet && (
-                    <span className='pl-0.5 text-theme-secondary-500 dark:text-theme-secondary-300'>
-                        {convert(value)}
-                    </span>
-                )
-            }
+            {!isDevnet && (
+                <span className='pl-0.5 text-theme-secondary-500 dark:text-theme-secondary-300'>
+                    {convert(value)}
+                </span>
+            )}
         </>
     );
 

--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -98,13 +98,11 @@ export const TransactionBody = ({
                         showSign: false,
                         primaryCurrency: primaryWallet?.currency() ?? 'ARK',
                     })}
-                    {
-                        !primaryWallet?.network().isTest() && (
-                            <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
-                                {convert(transaction.fee())}
-                            </span>
-                        )
-                    }
+                    {!primaryWallet?.network().isTest() && (
+                        <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
+                            {convert(transaction.fee())}
+                        </span>
+                    )}
                 </TrasactionItem>
 
                 <TrasactionItem title={t('COMMON.TIMESTAMP')}>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] hide fiat values in devnet](https://app.clickup.com/t/86dtaz6w8)

## Summary

- Fiat values are now hidden for devnet in transaction details page.

<img width="365" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/36ed41ea-146f-43eb-a111-1ed77fb653dc">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
