### PR TITLE
refactor: hide tooltip for details page

### DIFF
--- a/src/components/home/LatestTransactions.utils.tsx
+++ b/src/components/home/LatestTransactions.utils.tsx
@@ -218,11 +218,13 @@ export const renderAmount = ({
     isNegative,
     showSign,
     primaryCurrency,
+    displayTooltip = true,
 }: {
     value: number;
     isNegative: boolean;
     showSign: boolean;
     primaryCurrency: string;
+    displayTooltip?: boolean;
 }) => (
     <Amount
         value={value}
@@ -232,6 +234,7 @@ export const renderAmount = ({
         showSign={showSign}
         isNegative={isNegative}
         maxDigits={20}
+        displayTooltip={displayTooltip}
     />
 );
 

--- a/src/components/transaction/Transaction.blocks.tsx
+++ b/src/components/transaction/Transaction.blocks.tsx
@@ -129,6 +129,7 @@ export const TransactionAmount = ({
                     isNegative,
                     showSign,
                     primaryCurrency,
+                    displayTooltip: false,
                 })}
                 type={type}
                 selfAmount={selfAmount}

--- a/src/components/wallet/Amount.tsx
+++ b/src/components/wallet/Amount.tsx
@@ -15,6 +15,7 @@ interface AmountProperties {
     tooltipPlacement?: TippyProps['placement'];
     underlineOnHover?: boolean;
     maxDecimals?: number;
+    displayTooltip?: boolean;
 }
 
 const Amount = ({
@@ -27,6 +28,7 @@ const Amount = ({
     tooltipPlacement = 'top',
     underlineOnHover = false,
     maxDecimals,
+    displayTooltip = true,
 }: AmountProperties) => {
     const actualFormattedAmount = Helpers.Currency.format(value, ticker, { withTicker });
 
@@ -47,7 +49,7 @@ const Amount = ({
         }
     }
 
-    const tooltipDisabled = formattedAmount === actualFormattedAmount;
+    const tooltipDisabled = formattedAmount === actualFormattedAmount || !displayTooltip;
 
     return (
         <Tooltip


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] do not show tooltip when full value is shown](https://app.clickup.com/t/86dtbmu60)

## Summary

- `Amount` component has been refactored and now accepts `displayTooltip` property.
- Tooltip on details page will not be displayed anymore since it will always display the full value.

<img width="363" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/98c1db92-f4f7-4369-a242-42a230911205">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
