### PR TITLE
fix: add padding to multipayment badge

### DIFF
--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -83,7 +83,7 @@ const TransactionListItem = ({
                     <div className='flex flex-col gap-1'>
                         <span className='text-base font-medium leading-tight text-light-black dark:text-white'>
                             <TransactionTitle type={type} isSender={transaction.isSent()} />
-                            {type === TransactionType.MULTIPAYMENT && <MultipaymentBadge />}
+                            {type === TransactionType.MULTIPAYMENT && (<span className='ml-1.5'><MultipaymentBadge /></span>)}
                         </span>
                         <span className='text-sm font-normal leading-tight text-theme-secondary-500 dark:text-theme-secondary-300'>
                             <TransactionSecondaryText

--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -83,7 +83,11 @@ const TransactionListItem = ({
                     <div className='flex flex-col gap-1'>
                         <span className='text-base font-medium leading-tight text-light-black dark:text-white'>
                             <TransactionTitle type={type} isSender={transaction.isSent()} />
-                            {type === TransactionType.MULTIPAYMENT && (<span className='ml-1.5'><MultipaymentBadge /></span>)}
+                            {type === TransactionType.MULTIPAYMENT && (
+                                <span className='ml-1.5'>
+                                    <MultipaymentBadge />
+                                </span>
+                            )}
                         </span>
                         <span className='text-sm font-normal leading-tight text-theme-secondary-500 dark:text-theme-secondary-300'>
                             <TransactionSecondaryText


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] multi badge lacks padding](https://app.clickup.com/t/86dtbmue2)

## Summary

- Padding for `MULTI` badge has been added in the latest transactions section.

<img width="367" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/1603ae71-e63b-41e4-9cb1-6cddcdde9495">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
