### PR TITLE
refactor: use delegate info to display delegate address

### DIFF
--- a/src/components/home/LatestTransactions.utils.tsx
+++ b/src/components/home/LatestTransactions.utils.tsx
@@ -185,11 +185,11 @@ export const TransactionSecondaryText = ({
         case TransactionType.RETURN:
             return t('COMMON.TO_SELF');
         case TransactionType.SWAP:
-            return `${t('COMMON.TO')} ${voteDelegate}`;
+            return `${t('COMMON.TO')} ${voteDelegate.delegateName}`;
         case TransactionType.VOTE:
-            return voteDelegate;
+            return voteDelegate.delegateName;
         case TransactionType.UNVOTE:
-            return unvoteDelegate;
+            return unvoteDelegate.delegateName;
         case TransactionType.MULTIPAYMENT:
             return transaction.sender() === address ? (
                 <MultipaymentUniqueRecipients transaction={transaction} />

--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -63,18 +63,18 @@ export const TransactionBody = ({
 
                 {[TransactionType.VOTE, TransactionType.SWAP].includes(type) && (
                     <TrasactionItem title={t('COMMON.VOTE')}>
-                        {voteDelegate}
+                        {voteDelegate.delegateName}
                         <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
-                            {trimAddress(transaction.votes()[0], 'short')}
+                            {trimAddress(voteDelegate.delegateAddress, 'short')}
                         </span>
                     </TrasactionItem>
                 )}
 
                 {[TransactionType.UNVOTE, TransactionType.SWAP].includes(type) && (
                     <TrasactionItem title={t('COMMON.UNVOTE')}>
-                        {unvoteDelegate}
+                        {unvoteDelegate.delegateName}
                         <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
-                            {trimAddress(transaction.unvotes()[0], 'short')}
+                            {trimAddress(unvoteDelegate.delegateAddress, 'short')}
                         </span>
                     </TrasactionItem>
                 )}

--- a/src/lib/hooks/useDelegateInfo.ts
+++ b/src/lib/hooks/useDelegateInfo.ts
@@ -19,11 +19,14 @@ export const useDelegateInfo = (
         delegateAddress: string;
     }>({ delegateName: '', delegateAddress: '' });
 
-    const getDelegateInfo = async (address: string): Promise<{
+    const getDelegateInfo = async (
+        address: string,
+    ): Promise<{
         delegateName: string;
         delegateAddress: string;
     }> => {
-        let delegateName = '', delegateAddress = '';
+        let delegateName = '',
+            delegateAddress = '';
         const coin = primaryWallet?.network().coin() ?? 'ARK';
         const network = primaryWallet?.network().id() ?? 'ark.mainnet';
         try {
@@ -32,8 +35,7 @@ export const useDelegateInfo = (
             await env.delegates().sync(profile, coin, network);
         }
 
-        const delegate =
-            env.delegates().findByPublicKey(coin, network, address) || undefined;
+        const delegate = env.delegates().findByPublicKey(coin, network, address) || undefined;
 
         if (delegate) {
             delegateName = delegate.username() || '';

--- a/src/lib/hooks/useDelegateInfo.ts
+++ b/src/lib/hooks/useDelegateInfo.ts
@@ -10,10 +10,20 @@ export const useDelegateInfo = (
 ) => {
     const { env } = useEnvironmentContext();
     const { profile } = useProfileContext();
-    const [voteDelegate, setVoteDelegate] = useState<string>('');
-    const [unvoteDelegate, setUnvoteDelegate] = useState<string>('');
+    const [voteDelegate, setVoteDelegate] = useState<{
+        delegateName: string;
+        delegateAddress: string;
+    }>({ delegateName: '', delegateAddress: '' });
+    const [unvoteDelegate, setUnvoteDelegate] = useState<{
+        delegateName: string;
+        delegateAddress: string;
+    }>({ delegateName: '', delegateAddress: '' });
 
-    const getDelegateName = async (address: string) => {
+    const getDelegateInfo = async (address: string): Promise<{
+        delegateName: string;
+        delegateAddress: string;
+    }> => {
+        let delegateName = '', delegateAddress = '';
         const coin = primaryWallet?.network().coin() ?? 'ARK';
         const network = primaryWallet?.network().id() ?? 'ark.mainnet';
         try {
@@ -22,10 +32,15 @@ export const useDelegateInfo = (
             await env.delegates().sync(profile, coin, network);
         }
 
-        const delegateName =
-            env.delegates().findByPublicKey(coin, network, address)?.username() ?? '';
+        const delegate =
+            env.delegates().findByPublicKey(coin, network, address) || undefined;
 
-        return delegateName;
+        if (delegate) {
+            delegateName = delegate.username() || '';
+            delegateAddress = delegate.address();
+        }
+
+        return { delegateName, delegateAddress };
     };
 
     useEffect(() => {
@@ -35,15 +50,15 @@ export const useDelegateInfo = (
                 const unvoteAddress = transaction.unvotes()[0] || undefined;
 
                 if (voteAddress) {
-                    const voteDelegateName = await getDelegateName(voteAddress);
+                    const voteDelegate = await getDelegateInfo(voteAddress);
 
-                    setVoteDelegate(voteDelegateName);
+                    setVoteDelegate(voteDelegate);
                 }
 
                 if (unvoteAddress) {
-                    const unvoteDelegateName = await getDelegateName(unvoteAddress);
+                    const unvoteDelegate = await getDelegateInfo(unvoteAddress);
 
-                    setUnvoteDelegate(unvoteDelegateName);
+                    setUnvoteDelegate(unvoteDelegate);
                 }
             }
         })();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] show delegate address instead of public key](https://app.clickup.com/t/86dtbmuce)

## Summary

- `useDelegateInfo` hook has been refactored and now also fetches the delegate address.
- We now display the delegate address instead of its public key on the transaction details page.

<img width="357" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/fff4dc8b-0456-4933-b5d0-41dadb2b513e">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
