### PR TITLE
fix: display symbol for fiat values

### DIFF
--- a/src/components/transaction/Transaction.blocks.tsx
+++ b/src/components/transaction/Transaction.blocks.tsx
@@ -2,6 +2,7 @@ import cn from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { ExtendedConfirmedTransactionData } from '@ardenthq/sdk-profiles/distribution/esm/transaction.dto';
 import { AmountBadge, AmountBadgeType } from './details/AmountBadge';
+import Amount from '@/components/wallet/Amount';
 import { Icon, IconDefinition, Tooltip } from '@/shared/components';
 import {
     getAmountByAddress,
@@ -135,7 +136,11 @@ export const TransactionAmount = ({
             />
             {!isDevnet && (
                 <span className='pl-0.5 text-theme-secondary-500 dark:text-theme-secondary-300'>
-                    {convert(value)}
+                    <Amount
+                        value={convert(value)}
+                        ticker={primaryWallet?.exchangeCurrency() ?? 'USD'}
+                        underlineOnHover={true}
+                    />
                 </span>
             )}
         </>

--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -14,6 +14,7 @@ import { getType, renderAmount, TransactionType } from '@/components/home/Latest
 import { useExchangeRate } from '@/lib/hooks/useExchangeRate';
 import { useDelegateInfo } from '@/lib/hooks/useDelegateInfo';
 import { getTransactionDetailLink } from '@/lib/utils/networkUtils';
+import Amount from '@/components/wallet/Amount';
 
 export const TransactionBody = ({
     transaction,
@@ -24,7 +25,6 @@ export const TransactionBody = ({
     const { t } = useTranslation();
     const { copy } = useClipboard();
     const { voteDelegate, unvoteDelegate } = useDelegateInfo(transaction, primaryWallet);
-
     const { convert } = useExchangeRate({
         exchangeTicker: primaryWallet?.exchangeCurrency(),
         ticker: primaryWallet?.currency(),
@@ -100,7 +100,11 @@ export const TransactionBody = ({
                     })}
                     {!primaryWallet?.network().isTest() && (
                         <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
-                            {convert(transaction.fee())}
+                            <Amount
+                                value={convert(transaction.fee())}
+                                ticker={primaryWallet?.exchangeCurrency() ?? 'USD'}
+                                underlineOnHover={true}
+                            />
                         </span>
                     )}
                 </TrasactionItem>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] fiat value missing symbol](https://app.clickup.com/t/86dtbmu6r)

## Summary

- Symbol for fiat values will now be displayed in transaction details pages.

<img width="347" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/15d91ff7-d3f1-425d-8bf1-2fa690e34e9e">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
