### PR TITLE
refactor: display demo app button

### DIFF
--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -35,6 +35,16 @@ const AboutARK = () => {
             </div>
 
             <div className='flex flex-col gap-2 text-light-black dark:text-white'>
+                <RowLayout
+                    href={constants.ARK_CONNECT_DEMO}
+                    title={t('MISC.DEMO_APP')}
+                    iconTrailing='link-external'
+                    tabIndex={-1}
+                    className='flex w-full items-center justify-between rounded-2xl'
+                    target='_blank'
+                    rel='noopener noreferrer'
+                />
+
                 <div className='relative flex items-center'>
                     <RowLayout
                         title={t('MISC.SUPPORT_EMAIL')}

--- a/src/i18n/ns/misc.ts
+++ b/src/i18n/ns/misc.ts
@@ -1,6 +1,7 @@
 export default {
     ARK_CONNECT_SUPPORT_LEDGER: 'ARK Connect Support Ledger',
     ARK_CONNECT_SUPPORT: 'ARK Connect Support',
+    DEMO_APP: 'Demo App',
     INCORRECT_PASSWORD: 'Incorrect password',
     REACH_OUT_TO_SUPPORT_TEAM: 'Reach out to support team',
     SOMETHING_WENT_WRONG: 'Something went wrong!',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] move demo link to about](https://app.clickup.com/t/86dtbmvkw)

## Summary

- Button with link for demo app has been added in `About ARK` page.

<img width="369" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/68d5ca60-eed4-4ef9-a8da-23cf41607a60">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
