### PR TITLE
refactor: adjust dropdown shadow

### DIFF
--- a/src/components/settings/SettingsMenu.tsx
+++ b/src/components/settings/SettingsMenu.tsx
@@ -71,7 +71,7 @@ export const SettingsMenu = ({
 
     return (
         <div
-            className='mx-4 w-full rounded-xl bg-white shadow-dropdown dark:bg-subtle-black'
+            className='mx-4 w-full rounded-xl bg-white shadow-dropdown dark:bg-subtle-black dark:shadow-dropdown-dark'
             ref={dropdownRef}
         >
             <SafeOutlineOverflowContainer className='ml-0 w-full px-0'>

--- a/src/shared/components/header/AddressesDropdown.tsx
+++ b/src/shared/components/header/AddressesDropdown.tsx
@@ -76,7 +76,7 @@ export const AddressesDropdown = ({
 
     return (
         <div
-            className='mx-4 w-full rounded-xl bg-white shadow-dropdown dark:bg-subtle-black'
+            className='mx-4 w-full rounded-xl bg-white shadow-dropdown dark:bg-subtle-black dark:shadow-dropdown-dark'
             ref={dropdownRef}
         >
             <div className='border-b border-solid border-b-theme-secondary-200 dark:border-b-theme-secondary-600'>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,10 +26,11 @@ export default {
                 light: '0 1px 4px 0 rgba(0, 0, 0, 0.05)',
                 dark: '0 1px 4px 0 rgba(165, 165, 165, 0.08)',
                 dropdown:
-                    '0 4px 6px -2px rgba(16, 24, 40, 0.03), 0 12px 16px -4px rgba(16, 24, 40, 0.08)',
+                    '0px 12px 16px -4px rgba(16, 24, 40, 0.08), 0px 4px 6px -2px rgba(16, 24, 40, 0.03)',
                 'action-details': 'inset 0 0 0 1px  var(--theme-color-secondary-200)',
                 'action-details-dark': 'inset 0 0 0 1px  var(--theme-color-secondary-700)',
                 'secondary-dark': '0 1px 2px 0 rgba(16, 24, 40, 0.05)',
+                'dropdown-dark': '0px 4px 24px 0px rgba(0, 0, 0, 0.50)'
             },
             dropShadow: {
                 dark: '0 1px 3px  rgba(16, 24, 40, 0.10)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,7 +30,7 @@ export default {
                 'action-details': 'inset 0 0 0 1px  var(--theme-color-secondary-200)',
                 'action-details-dark': 'inset 0 0 0 1px  var(--theme-color-secondary-700)',
                 'secondary-dark': '0 1px 2px 0 rgba(16, 24, 40, 0.05)',
-                'dropdown-dark': '0px 4px 24px 0px rgba(0, 0, 0, 0.50)'
+                'dropdown-dark': '0px 4px 24px 0px rgba(0, 0, 0, 0.50)',
             },
             dropShadow: {
                 dark: '0 1px 3px  rgba(16, 24, 40, 0.10)',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] adjust dropdown shadow](https://app.clickup.com/t/86dtbmvm5)

## Summary

- New `dropdown-dark` shadow variable.
- `dropdown` variable for shadows has been adjusted to match the designs.
- Shadow for dropdowns in dark mode has been adjusted.

## Screenshots

- Light mode: 
<img width="365" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/421c3d66-1961-4871-9751-9684b9f90606">

- Dark mode:
<img width="364" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/f64a1a05-d6a7-4df8-be8c-8a47e9475712">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
