### PR TITLE
fix: declare multisignature in i18n files

### DIFF
--- a/src/i18n/ns/common.ts
+++ b/src/i18n/ns/common.ts
@@ -18,6 +18,7 @@ export default {
     MINIMUN_REQUIRED_SIGNATURES: 'Minimum Required Signatures',
     MESSAGE: 'Message',
     MULTI: 'Multi',
+    MULTISIGNATURE: 'Multisignature',
     MULTISIGNATURE_ADDRESS: 'Multisignature Address',
     MULTISIGNATURE_PARTICIPANTS: 'Multisignature Participants',
     NOT_AVAILABLE: 'N/A',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] word missing in i18n](https://app.clickup.com/t/86dtbnmpx)

## Summary

- `Multisignature` has been declared in i18n translation files.

<img width="359" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/96c38f59-6844-44e0-b0f5-ef169c7974a1">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
