### PR TITLE
feat: loading state for transaction details

### DIFF
--- a/src/pages/TransactionDetails.tsx
+++ b/src/pages/TransactionDetails.tsx
@@ -33,7 +33,7 @@ const TransactionDetails = () => {
     const primaryWallet = usePrimaryWallet();
     const { transactionId } = useParams<{ transactionId: string }>();
 
-    const { data: transactionData, refetch } = useQuery<TransactionDetailsResponse>(
+    const { data: transactionData, refetch, isLoading } = useQuery<TransactionDetailsResponse>(
         ['transaction-details', transactionId],
         () => fetchTransactionDetails(primaryWallet, transactionId),
         {
@@ -51,13 +51,15 @@ const TransactionDetails = () => {
 
     return (
         <SubPageLayout title={t('PAGES.TRANSACTION_DETAILS.PAGE_TITLE')}>
-            {transactionData ? (
+            {transactionData && !isLoading ? (
                 <>
                     <TransactionHeader transaction={transactionData} className='mb-4' />
                     <TransactionBody transaction={transactionData} />
                 </>
             ) : (
-                <Loader />
+                <div className='h-full w-full flex justify-center items-center'>
+                    <Loader variant='big' />
+                </div>
             )}
         </SubPageLayout>
     );

--- a/src/pages/TransactionDetails.tsx
+++ b/src/pages/TransactionDetails.tsx
@@ -33,7 +33,11 @@ const TransactionDetails = () => {
     const primaryWallet = usePrimaryWallet();
     const { transactionId } = useParams<{ transactionId: string }>();
 
-    const { data: transactionData, refetch, isLoading } = useQuery<TransactionDetailsResponse>(
+    const {
+        data: transactionData,
+        refetch,
+        isLoading,
+    } = useQuery<TransactionDetailsResponse>(
         ['transaction-details', transactionId],
         () => fetchTransactionDetails(primaryWallet, transactionId),
         {
@@ -57,7 +61,7 @@ const TransactionDetails = () => {
                     <TransactionBody transaction={transactionData} />
                 </>
             ) : (
-                <div className='h-full w-full flex justify-center items-center'>
+                <div className='flex h-full w-full items-center justify-center'>
                     <Loader variant='big' />
                 </div>
             )}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] implement loader for details data](https://app.clickup.com/t/86dt9ncnn)

## Summary

- We now display a spinner loader when the query to fetch the transaction details is loading.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
