### PR TITLE
refactor: display full transaction id in tooltip

### DIFF
--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -6,7 +6,7 @@ import {
     TransactionUniqueRecipients,
 } from '../Transaction.blocks';
 import { TrasactionItem } from './TrasactionItem';
-import { Button, ExternalLink, Icon } from '@/shared/components';
+import { Button, ExternalLink, Icon, Tooltip } from '@/shared/components';
 import useClipboard from '@/lib/hooks/useClipboard';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
 import trimAddress from '@/lib/utils/trimAddress';
@@ -135,7 +135,9 @@ export const TransactionBody = ({
 
                 <TrasactionItem title={t('COMMON.TRANSACTION_ID')}>
                     <div className='flex w-full flex-row items-center justify-between'>
-                        <span>{trimAddress(transaction.id(), 'longest')}</span>
+                        <Tooltip content={transaction.id()} className='break-words' >
+                            <span>{trimAddress(transaction.id(), 'longest')}</span>
+                        </Tooltip>
                         <button
                             type='button'
                             className='block'

--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -135,7 +135,7 @@ export const TransactionBody = ({
 
                 <TrasactionItem title={t('COMMON.TRANSACTION_ID')}>
                     <div className='flex w-full flex-row items-center justify-between'>
-                        <Tooltip content={transaction.id()} className='break-words' >
+                        <Tooltip content={transaction.id()} className='break-words'>
                             <span>{trimAddress(transaction.id(), 'longest')}</span>
                         </Tooltip>
                         <button


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] tooltip for transaction id in details page](https://app.clickup.com/t/86dtc02b2)

## Summary

- Tooltip to display the full transaction id has been implemented in transaction details page.

<img width="371" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/d60e561c-0e15-45d0-b527-e285df52b910">

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
