### PR TITLE
refactor: display dash for non-payment transactions

### DIFF
--- a/src/components/home/LatestTransactions.utils.tsx
+++ b/src/components/home/LatestTransactions.utils.tsx
@@ -248,6 +248,15 @@ export const LatestTransactionAmount = ({
     const type = getType(transaction);
     const isMultipayment = type === TransactionType.MULTIPAYMENT;
     const amount = transaction.amount();
+    const paymentTypes = [
+        TransactionType.SEND,
+        TransactionType.RECEIVE,
+        TransactionType.RETURN,
+        TransactionType.MULTIPAYMENT,
+    ];
+    if (!paymentTypes.includes(type as TransactionType)) {
+        return <span className='flex items-center justify-center h-5'><hr className='w-2 h-0.5 bg-theme-secondary-300 dark:bg-theme-secondary-500' /></span>;
+    }
 
     if (isMultipayment) {
         const uniqueRecipients = getUniqueRecipients(transaction);

--- a/src/components/home/LatestTransactions.utils.tsx
+++ b/src/components/home/LatestTransactions.utils.tsx
@@ -255,7 +255,11 @@ export const LatestTransactionAmount = ({
         TransactionType.MULTIPAYMENT,
     ];
     if (!paymentTypes.includes(type as TransactionType)) {
-        return <span className='flex items-center justify-center h-5'><hr className='w-2 h-0.5 bg-theme-secondary-300 dark:bg-theme-secondary-500' /></span>;
+        return (
+            <span className='flex h-5 items-center justify-center'>
+                <hr className='h-0.5 w-2 bg-theme-secondary-300 dark:bg-theme-secondary-500' />
+            </span>
+        );
     }
 
     if (isMultipayment) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[dashboard] display "-" for non-payment transactions](https://app.clickup.com/t/86dtc2rgd)

## Summary

- A dash is now displayed in amount section for non-payment transactions.

<img width="370" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/1307776e-e3f1-4861-a4f4-a82f30ba42ac">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
