### PR TITLE
fix: remove redundant amount tooltips

### DIFF
--- a/src/components/wallet/Amount.tsx
+++ b/src/components/wallet/Amount.tsx
@@ -30,7 +30,7 @@ const Amount = ({
     maxDecimals,
     displayTooltip = true,
 }: AmountProperties) => {
-    const actualFormattedAmount = Helpers.Currency.format(value, ticker, { withTicker });
+    let actualFormattedAmount = Helpers.Currency.format(value, ticker, { withTicker });
 
     let formattedAmount = cropToMaxDigits({
         value,
@@ -46,6 +46,7 @@ const Amount = ({
     } else if (showSign) {
         if (value !== 0) {
             formattedAmount = `${isNegative ? '-' : '+'}${formattedAmount}`;
+            actualFormattedAmount = `${isNegative ? '-' : '+'}${actualFormattedAmount}`;
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] remove amount tooltip](https://app.clickup.com/t/86dt7wm4c)

## Summary

- `Amount` component now takes consideration of signs when checking if the tooltip should be displayed or not.

<img width="358" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/b4ed4379-4887-492c-ab63-02a2b360f0d9">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
