### PR TITLE
fix: skeleton loaders not appearing

### DIFF
--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -120,7 +120,11 @@ export const TransactionSecondaryText = ({
                 <Skeleton width={90} height={18} />
             );
         case TransactionType.VOTE:
-            return voteDelegate.delegateName ? voteDelegate.delegateName : <Skeleton width={90} height={18} />;
+            return voteDelegate.delegateName ? (
+                voteDelegate.delegateName
+            ) : (
+                <Skeleton width={90} height={18} />
+            );
         case TransactionType.UNVOTE:
             return unvoteDelegate.delegateName ? (
                 unvoteDelegate.delegateName

--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -114,15 +114,15 @@ export const TransactionSecondaryText = ({
         case TransactionType.RETURN:
             return t('COMMON.TO_SELF');
         case TransactionType.SWAP:
-            return voteDelegate ? (
+            return voteDelegate.delegateName ? (
                 `${t('COMMON.TO')} ${voteDelegate.delegateName}`
             ) : (
                 <Skeleton width={90} height={18} />
             );
         case TransactionType.VOTE:
-            return voteDelegate ? voteDelegate.delegateName : <Skeleton width={90} height={18} />;
+            return voteDelegate.delegateName ? voteDelegate.delegateName : <Skeleton width={90} height={18} />;
         case TransactionType.UNVOTE:
-            return unvoteDelegate ? (
+            return unvoteDelegate.delegateName ? (
                 unvoteDelegate.delegateName
             ) : (
                 <Skeleton width={90} height={18} />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[dashboard] skeleton loader not appearing](https://app.clickup.com/t/86dtcw0eb)

## Summary

- The condition to render the skeleton loader now relies on having the delegate name property and not the object.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
