### PR TITLE
refactor: swap vote and unvote positions in transaction details

### DIFF
--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -62,20 +62,20 @@ export const TransactionBody = ({
                     </TrasactionItem>
                 )}
 
-                {[TransactionType.VOTE, TransactionType.SWAP].includes(type) && (
-                    <TrasactionItem title={t('COMMON.VOTE')}>
-                        {voteDelegate.delegateName}
-                        <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
-                            {trimAddress(voteDelegate.delegateAddress, 'short')}
-                        </span>
-                    </TrasactionItem>
-                )}
-
                 {[TransactionType.UNVOTE, TransactionType.SWAP].includes(type) && (
                     <TrasactionItem title={t('COMMON.UNVOTE')}>
                         {unvoteDelegate.delegateName}
                         <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
                             {trimAddress(unvoteDelegate.delegateAddress, 'short')}
+                        </span>
+                    </TrasactionItem>
+                )}
+
+                {[TransactionType.VOTE, TransactionType.SWAP].includes(type) && (
+                    <TrasactionItem title={t('COMMON.VOTE')}>
+                        {voteDelegate.delegateName}
+                        <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
+                            {trimAddress(voteDelegate.delegateAddress, 'short')}
                         </span>
                     </TrasactionItem>
                 )}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[swap vote] swap Vote and Unvote to match design](https://app.clickup.com/t/86dtcw9we)

## Summary

- Vote and Unvote positions in transaction details have been swapped to match designs.

<img width="359" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/bc615410-4fdd-47d3-9e24-34d2255bb470">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
