### PR TITLE
refactor: trim address in transaction pages

### DIFF
--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -1,8 +1,11 @@
-import { useTranslation } from 'react-i18next';
-import cn from 'classnames';
-import dayjs from 'dayjs';
-import { ExtendedConfirmedTransactionData } from '@ardenthq/sdk-profiles/distribution/esm/transaction.dto';
-import { IReadWriteWallet } from '@ardenthq/sdk-profiles/distribution/esm/wallet.contract';
+import {
+    Button,
+    EmptyConnectionsIcon,
+    ExternalLink,
+    Icon,
+    InternalLink,
+    Tooltip,
+} from '@/shared/components';
 import {
     getAmountByAddress,
     getMultipaymentAmounts,
@@ -12,20 +15,18 @@ import {
     renderAmount,
     TransactionType,
 } from './LatestTransactions.utils';
-import { getTimeAgo } from '@/lib/utils/getTimeAgo';
-import {
-    Button,
-    EmptyConnectionsIcon,
-    ExternalLink,
-    Icon,
-    InternalLink,
-    Tooltip,
-} from '@/shared/components';
-import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
+
+import cn from 'classnames';
+import dayjs from 'dayjs';
+import { ExtendedConfirmedTransactionData } from '@ardenthq/sdk-profiles/distribution/esm/transaction.dto';
 import { getExplorerDomain } from '@/lib/utils/networkUtils';
-import { useDelegateInfo } from '@/lib/hooks/useDelegateInfo';
-import trimAddress from '@/lib/utils/trimAddress';
+import { getTimeAgo } from '@/lib/utils/getTimeAgo';
+import { IReadWriteWallet } from '@ardenthq/sdk-profiles/distribution/esm/wallet.contract';
 import { Skeleton } from '@/shared/components/utils/Skeleton';
+import trimAddress from '@/lib/utils/trimAddress';
+import { useDelegateInfo } from '@/lib/hooks/useDelegateInfo';
+import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
+import { useTranslation } from 'react-i18next';
 
 export const TransactionTitle = ({
     type,
@@ -70,7 +71,7 @@ const PaymentInfo = ({ address, isSent }: { address: string; isSent: boolean }) 
     return (
         <Tooltip content={address}>
             <span>
-                {isSent ? t('COMMON.TO') : t('COMMON.FROM')} {trimAddress(address, 10)}
+                {isSent ? t('COMMON.TO') : t('COMMON.FROM')} {trimAddress(address, 'short')}
             </span>
         </Tooltip>
     );

--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -1,11 +1,8 @@
-import {
-    Button,
-    EmptyConnectionsIcon,
-    ExternalLink,
-    Icon,
-    InternalLink,
-    Tooltip,
-} from '@/shared/components';
+import cn from 'classnames';
+import dayjs from 'dayjs';
+import { ExtendedConfirmedTransactionData } from '@ardenthq/sdk-profiles/distribution/esm/transaction.dto';
+import { IReadWriteWallet } from '@ardenthq/sdk-profiles/distribution/esm/wallet.contract';
+import { useTranslation } from 'react-i18next';
 import {
     getAmountByAddress,
     getMultipaymentAmounts,
@@ -15,18 +12,21 @@ import {
     renderAmount,
     TransactionType,
 } from './LatestTransactions.utils';
+import {
+    Button,
+    EmptyConnectionsIcon,
+    ExternalLink,
+    Icon,
+    InternalLink,
+    Tooltip,
+} from '@/shared/components';
 
-import cn from 'classnames';
-import dayjs from 'dayjs';
-import { ExtendedConfirmedTransactionData } from '@ardenthq/sdk-profiles/distribution/esm/transaction.dto';
 import { getExplorerDomain } from '@/lib/utils/networkUtils';
 import { getTimeAgo } from '@/lib/utils/getTimeAgo';
-import { IReadWriteWallet } from '@ardenthq/sdk-profiles/distribution/esm/wallet.contract';
 import { Skeleton } from '@/shared/components/utils/Skeleton';
 import trimAddress from '@/lib/utils/trimAddress';
 import { useDelegateInfo } from '@/lib/hooks/useDelegateInfo';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
-import { useTranslation } from 'react-i18next';
 
 export const TransactionTitle = ({
     type,

--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -70,7 +70,7 @@ const PaymentInfo = ({ address, isSent }: { address: string; isSent: boolean }) 
     return (
         <Tooltip content={address}>
             <span>
-                {isSent ? t('COMMON.TO') : t('COMMON.FROM')} {trimAddress(address, 'short')}
+                {isSent ? t('COMMON.TO') : t('COMMON.FROM')} {trimAddress(address, 10)}
             </span>
         </Tooltip>
     );

--- a/src/components/transaction/Transaction.blocks.tsx
+++ b/src/components/transaction/Transaction.blocks.tsx
@@ -53,7 +53,7 @@ const AddressBlock = ({
                     'text-theme-secondary-500 dark:text-theme-secondary-300': isSecondary,
                 })}
             >
-                {trimAddress(address, 'short')}
+                {trimAddress(address, 10)}
             </span>
         </Tooltip>
     );

--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -66,7 +66,7 @@ export const TransactionBody = ({
                     <TrasactionItem title={t('COMMON.VOTE')}>
                         {voteDelegate.delegateName}
                         <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
-                            {trimAddress(voteDelegate.delegateAddress, 'short')}
+                            {trimAddress(voteDelegate.delegateAddress, 10)}
                         </span>
                     </TrasactionItem>
                 )}
@@ -75,7 +75,7 @@ export const TransactionBody = ({
                     <TrasactionItem title={t('COMMON.UNVOTE')}>
                         {unvoteDelegate.delegateName}
                         <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
-                            {trimAddress(unvoteDelegate.delegateAddress, 'short')}
+                            {trimAddress(unvoteDelegate.delegateAddress, 10)}
                         </span>
                     </TrasactionItem>
                 )}

--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -1,22 +1,22 @@
-import { Button, ExternalLink, Icon, Tooltip } from '@/shared/components';
-import { getType, renderAmount, TransactionType } from '@/components/home/LatestTransactions.utils';
+import { ExtendedConfirmedTransactionData } from '@ardenthq/sdk-profiles/distribution/esm/transaction.dto';
+import { useTranslation } from 'react-i18next';
 import {
     TransactionAddress,
     TransactionAmount,
     TransactionUniqueRecipients,
 } from '../Transaction.blocks';
+import { TrasactionItem } from './TrasactionItem';
+import { Button, ExternalLink, Icon, Tooltip } from '@/shared/components';
+import { getType, renderAmount, TransactionType } from '@/components/home/LatestTransactions.utils';
 
 import Amount from '@/components/wallet/Amount';
-import { ExtendedConfirmedTransactionData } from '@ardenthq/sdk-profiles/distribution/esm/transaction.dto';
 import { formatUnixTimestamp } from '@/lib/utils/formatUnixTimestsamp';
 import { getTransactionDetailLink } from '@/lib/utils/networkUtils';
-import { TrasactionItem } from './TrasactionItem';
 import trimAddress from '@/lib/utils/trimAddress';
 import useClipboard from '@/lib/hooks/useClipboard';
 import { useDelegateInfo } from '@/lib/hooks/useDelegateInfo';
 import { useExchangeRate } from '@/lib/hooks/useExchangeRate';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
-import { useTranslation } from 'react-i18next';
 
 export const TransactionBody = ({
     transaction,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transaction details] all addresses should be 5...5](https://app.clickup.com/t/86dtcvm0u)

## Summary

- All addresses in latest transactions list and transaction details page have been refactored and now are trimmed to 10 characters, 5 per side.

<img width="363" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/d5b00dc2-7c11-4429-9e21-29b6157eacdd">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
