### PR TITLE
refactor: re-enable send/receive buttons

### DIFF
--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -246,7 +246,7 @@ export const TransactionsList = ({
     const { t } = useTranslation();
 
     return (
-        <div className='custom-scroll max-h-[320px] overflow-auto'>
+        <div className='custom-scroll max-h-[270px] overflow-auto'>
             {transactions.map((transaction, index) => (
                 <TransactionListItem key={index} transaction={transaction} />
             ))}

--- a/src/components/home/LatestTransactions.tsx
+++ b/src/components/home/LatestTransactions.tsx
@@ -65,7 +65,7 @@ export const LatestTransactions = () => {
                     )}
                 </div>
             ) : (
-                <div className='flex h-[320px] w-full items-center justify-center'>
+                <div className='flex h-[270px] w-full items-center justify-center'>
                     <Loader
                         variant='big'
                         className='dark:border-theme-secondary-700 dark:border-t-theme-primary-650'

--- a/src/components/home/TransactionButtons.tsx
+++ b/src/components/home/TransactionButtons.tsx
@@ -17,12 +17,21 @@ export const TransactionButtons = () => {
                 placement='top'
             >
                 <div>
-                    <Button iconLeading='send' variant='secondary' disabled={walletBalance === 0} onClick={() => navigate('/transaction/send')}>
+                    <Button
+                        iconLeading='send'
+                        variant='secondary'
+                        disabled={walletBalance === 0}
+                        onClick={() => navigate('/transaction/send')}
+                    >
                         {t('COMMON.SEND')}
                     </Button>
                 </div>
             </Tooltip>
-            <Button iconLeading='receive' variant='secondary' onClick={() => navigate('/transaction/receive')}>
+            <Button
+                iconLeading='receive'
+                variant='secondary'
+                onClick={() => navigate('/transaction/receive')}
+            >
                 {t('COMMON.RECEIVE')}
             </Button>
         </div>

--- a/src/components/home/TransactionButtons.tsx
+++ b/src/components/home/TransactionButtons.tsx
@@ -1,10 +1,12 @@
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
 import { Button, Tooltip } from '@/shared/components';
 
 export const TransactionButtons = () => {
     const { t } = useTranslation();
     const primaryWallet = usePrimaryWallet();
+    const navigate = useNavigate();
     const walletBalance = primaryWallet?.balance() ?? 0;
 
     return (
@@ -15,12 +17,12 @@ export const TransactionButtons = () => {
                 placement='top'
             >
                 <div>
-                    <Button iconLeading='send' variant='secondary' disabled={walletBalance === 0}>
+                    <Button iconLeading='send' variant='secondary' disabled={walletBalance === 0} onClick={() => navigate('/transaction/send')}>
                         {t('COMMON.SEND')}
                     </Button>
                 </div>
             </Tooltip>
-            <Button iconLeading='receive' variant='secondary'>
+            <Button iconLeading='receive' variant='secondary' onClick={() => navigate('/transaction/receive')}>
                 {t('COMMON.RECEIVE')}
             </Button>
         </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,6 +7,7 @@ import constants from '@/constants';
 import { useProfileContext } from '@/lib/context/Profile';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
 import { LatestTransactions } from '@/components/home/LatestTransactions';
+import { TransactionButtons } from '@/components/home/TransactionButtons';
 const Home = () => {
     const { convertedBalance } = useProfileContext();
 
@@ -70,7 +71,7 @@ const Home = () => {
                     </div>
                 </div>
             </div>
-
+            <TransactionButtons />
             <LatestTransactions />
         </Layout>
     );

--- a/src/pages/Receive.tsx
+++ b/src/pages/Receive.tsx
@@ -1,0 +1,14 @@
+import { useTranslation } from 'react-i18next';
+import SubPageLayout from '@/components/settings/SubPageLayout';
+
+const Receive = () => {
+    const { t } = useTranslation();
+
+    return (
+        <SubPageLayout title={t('COMMON.RECEIVE')}>
+            Receive page
+        </SubPageLayout>
+    );
+};
+
+export default Receive;

--- a/src/pages/Receive.tsx
+++ b/src/pages/Receive.tsx
@@ -4,11 +4,7 @@ import SubPageLayout from '@/components/settings/SubPageLayout';
 const Receive = () => {
     const { t } = useTranslation();
 
-    return (
-        <SubPageLayout title={t('COMMON.RECEIVE')}>
-            Receive page
-        </SubPageLayout>
-    );
+    return <SubPageLayout title={t('COMMON.RECEIVE')}>Receive page</SubPageLayout>;
 };
 
 export default Receive;

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -4,11 +4,7 @@ import SubPageLayout from '@/components/settings/SubPageLayout';
 const Send = () => {
     const { t } = useTranslation();
 
-    return (
-        <SubPageLayout title={t('COMMON.SEND')}>
-            Send page
-        </SubPageLayout>
-    );
+    return <SubPageLayout title={t('COMMON.SEND')}>Send page</SubPageLayout>;
 };
 
 export default Send;

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -1,0 +1,14 @@
+import { useTranslation } from 'react-i18next';
+import SubPageLayout from '@/components/settings/SubPageLayout';
+
+const Send = () => {
+    const { t } = useTranslation();
+
+    return (
+        <SubPageLayout title={t('COMMON.SEND')}>
+            Send page
+        </SubPageLayout>
+    );
+};
+
+export default Send;

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -25,6 +25,8 @@ import WalletNotFound from '@/pages/WalletNotFound';
 import ImportWithLedger from '@/pages/ImportWithLedger';
 import TransactionDetails from '@/pages/TransactionDetails';
 import { AddressSettings } from '@/components/wallet/AddressSettings';
+import Send from '@/pages/Send';
+import Receive from '@/pages/Receive';
 
 type RouteData = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -171,6 +173,16 @@ const routes: RouteData[] = [
         path: '/transaction/:transactionId',
         title: 'Transaction Details',
     },
+    {
+        Component: Send,
+        path: '/transaction/send',
+        title: 'Send',
+    },
+    {
+        Component: Receive,
+        path: '/transaction/receive',
+        title: 'Receive',
+    }
 ];
 
 export default routes;

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -182,7 +182,7 @@ const routes: RouteData[] = [
         Component: Receive,
         path: '/transaction/receive',
         title: 'Receive',
-    }
+    },
 ];
 
 export default routes;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] re-enable send/receive buttons](https://app.clickup.com/t/86dtbmvr2)

## Summary

- `TransactionButtons` have been added back to the home page.
- Height for latest transactions list has been fixed.
- Basic structure for `Send` and `Receive` pages has been added.

<img width="365" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/afa33d60-c897-42ee-ad96-026d230d9713">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
