### PR TITLE
fix: remove outline for transaction list in firefox

### DIFF
--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -186,7 +186,10 @@ const TransactionListItem = ({
     ].includes(type as TransactionType);
 
     return (
-        <InternalLink to={`/transaction/${transaction.id()}`} className='hover:no-underline outline-none'>
+        <InternalLink
+            to={`/transaction/${transaction.id()}`}
+            className='outline-none hover:no-underline'
+        >
             <div className='transition-smoothEase flex h-[76px] w-full flex-row items-center justify-center gap-3 p-4 hover:bg-theme-secondary-50 dark:hover:bg-theme-secondary-700'>
                 <div className='flex h-11 min-w-11 items-center justify-center rounded-xl border border-theme-secondary-200 bg-white text-theme-secondary-500 dark:border-theme-secondary-600 dark:bg-subtle-black dark:text-theme-secondary-300'>
                     <Icon

--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -186,7 +186,7 @@ const TransactionListItem = ({
     ].includes(type as TransactionType);
 
     return (
-        <InternalLink to={`/transaction/${transaction.id()}`} className='hover:no-underline'>
+        <InternalLink to={`/transaction/${transaction.id()}`} className='hover:no-underline outline-none'>
             <div className='transition-smoothEase flex h-[76px] w-full flex-row items-center justify-center gap-3 p-4 hover:bg-theme-secondary-50 dark:hover:bg-theme-secondary-700'>
                 <div className='flex h-11 min-w-11 items-center justify-center rounded-xl border border-theme-secondary-200 bg-white text-theme-secondary-500 dark:border-theme-secondary-600 dark:bg-subtle-black dark:text-theme-secondary-300'>
                     <Icon


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[firefox] transaction list styling issue ](https://app.clickup.com/t/86dtd7vje)

## Summary

- Outline in transaction list items in Firefox has been removed.

<img width="378" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/ccd700d2-264b-4afa-9905-529480908f19">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
