### PR TITLE
refactor: dash color in transaction items

### DIFF
--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -298,7 +298,7 @@ export const LatestTransactionAmount = ({
     if (!paymentTypes.includes(type as TransactionType)) {
         return (
             <span className='flex h-5 items-center justify-center'>
-                <div className='h-0.5 w-2 bg-theme-secondary-300 dark:bg-theme-secondary-500' />
+                <span className='h-0.5 w-2 bg-theme-secondary-300 dark:bg-theme-secondary-500' />
             </span>
         );
     }

--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -298,7 +298,7 @@ export const LatestTransactionAmount = ({
     if (!paymentTypes.includes(type as TransactionType)) {
         return (
             <span className='flex h-5 items-center justify-center'>
-                <hr className='h-0.5 w-2 bg-theme-secondary-300 dark:bg-theme-secondary-500' />
+                <div className='h-0.5 w-2 bg-theme-secondary-300 dark:bg-theme-secondary-500' />
             </span>
         );
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] dash should be lighter gray](https://app.clickup.com/t/86dtdk7zg)

## Summary

- Dash has been refactored and is now a `span` to make sure it fully uses the css classnames set.

<img width="366" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/b2d01345-12ae-4a06-86ff-4941bfc8a86a">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
