### PR TITLE
refactor: handle transactions amounts

### DIFF
--- a/src/components/home/LatestTransactions.utils.tsx
+++ b/src/components/home/LatestTransactions.utils.tsx
@@ -128,5 +128,7 @@ export const renderAmount = ({
         isNegative={isNegative}
         maxDigits={20}
         displayTooltip={displayTooltip}
+        maxDecimals={2}
+        hideSmallValues
     />
 );

--- a/src/components/wallet/Amount.tsx
+++ b/src/components/wallet/Amount.tsx
@@ -33,7 +33,7 @@ const Amount = ({
     hideSmallValues = false,
 }: AmountProperties) => {
     let actualFormattedAmount = Helpers.Currency.format(value, ticker, { withTicker });
-    const valueToFormat = (hideSmallValues && value !== 0 && value < 0.01) ? 0.01 : value;
+    const valueToFormat = hideSmallValues && value !== 0 && value < 0.01 ? 0.01 : value;
 
     let formattedAmount = cropToMaxDigits({
         value: valueToFormat,
@@ -43,7 +43,7 @@ const Amount = ({
         maxDecimals,
     });
 
-    if(valueToFormat !== value) {
+    if (valueToFormat !== value) {
         formattedAmount = `< ${formattedAmount}`;
     }
 

--- a/src/components/wallet/Amount.tsx
+++ b/src/components/wallet/Amount.tsx
@@ -16,6 +16,7 @@ interface AmountProperties {
     underlineOnHover?: boolean;
     maxDecimals?: number;
     displayTooltip?: boolean;
+    hideSmallValues?: boolean;
 }
 
 const Amount = ({
@@ -29,16 +30,22 @@ const Amount = ({
     underlineOnHover = false,
     maxDecimals,
     displayTooltip = true,
+    hideSmallValues = false,
 }: AmountProperties) => {
     let actualFormattedAmount = Helpers.Currency.format(value, ticker, { withTicker });
+    const valueToFormat = (hideSmallValues && value !== 0 && value < 0.01) ? 0.01 : value;
 
     let formattedAmount = cropToMaxDigits({
-        value,
+        value: valueToFormat,
         ticker,
         maxDigits,
         withTicker,
         maxDecimals,
     });
+
+    if(valueToFormat !== value) {
+        formattedAmount = `< ${formattedAmount}`;
+    }
 
     if (value === 0 && !['ARK', 'DARK'].includes(formattedAmount.split(' ')[1])) {
         const currencySymbol = formattedAmount.match(/[^\d.,]+/);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] handle multipayment amounts](https://app.clickup.com/t/86dtdk805)

## Summary

- `maxDecimals` to display in amounts has been set as 2.
- `< 0.01` will be displayed in case we have any amount with 3 or more decimals and is lower than `0.01`

<img width="366" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/1059bef0-776d-4533-925b-140e7596b693">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
