### PR TITLE
refactor: show delegate name for resignation/registration transactions

### DIFF
--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -138,6 +138,9 @@ export const TransactionSecondaryText = ({
             ) : (
                 <PaymentInfo address={transaction.sender()} isSent={false} />
             );
+        case TransactionType.REGISTRATION:
+        case TransactionType.RESIGNATION:
+            return transaction.wallet().username();
         default:
             return t('COMMON.CONTRACT');
     }

--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -140,7 +140,7 @@ export const TransactionSecondaryText = ({
             );
         case TransactionType.REGISTRATION:
         case TransactionType.RESIGNATION:
-            return transaction.wallet().username();
+            return transaction.wallet().username() ?? '';
         default:
             return t('COMMON.CONTRACT');
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] Show Delegate name instead of contract](https://app.clickup.com/t/86dtdkxz6)

## Summary

- Delegate name is now displayed for resignation and registration-type transactions.

<img width="361" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/97aebfad-7da8-4b82-8b22-3cd89dd5c09a">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
