### PR TITLE
fix: display full vote/unvote address in tooltip

### DIFF
--- a/src/components/approve/ActionBody.tsx
+++ b/src/components/approve/ActionBody.tsx
@@ -143,7 +143,7 @@ export const ActionBody = ({
             {unvote?.delegateAddress && !wallet?.isLedger() && (
                 <ActionAddressRow
                     label={t('COMMON.UNVOTE_DELEGATE_ADDRESS')}
-                    address={trimAddress(unvote.delegateAddress ?? '', 10)}
+                    address={unvote.delegateAddress}
                 />
             )}
 
@@ -170,7 +170,7 @@ export const ActionBody = ({
             {vote?.delegateAddress && !wallet?.isLedger() && (
                 <ActionAddressRow
                     label={t('COMMON.VOTE_DELEGATE_ADDRESS')}
-                    address={trimAddress(vote.delegateAddress ?? '', 10)}
+                    address={vote.delegateAddress}
                 />
             )}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[vote] vote/unvote address tooltip not showing full address](https://app.clickup.com/t/86dtdnem4)

## Summary

- Vote/Unvote address is fully displayed in tooltip.

<img width="369" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/854d8a0f-1727-48f8-b8cb-24a4abb0f9fa">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
