### PR TITLE
refactor: move fiat value to right

### DIFF
--- a/src/components/transaction/Transaction.blocks.tsx
+++ b/src/components/transaction/Transaction.blocks.tsx
@@ -123,7 +123,7 @@ export const TransactionAmount = ({
         selfAmount?: string;
         isDevnet?: boolean;
     }) => (
-        <>
+        <div className='w-full flex justify-between items-center'>
             <AmountBadge
                 amount={renderAmount({
                     value,
@@ -144,7 +144,7 @@ export const TransactionAmount = ({
                     />
                 </span>
             )}
-        </>
+        </div>
     );
 
     if (transaction.isMultiPayment()) {

--- a/src/components/transaction/Transaction.blocks.tsx
+++ b/src/components/transaction/Transaction.blocks.tsx
@@ -123,7 +123,7 @@ export const TransactionAmount = ({
         selfAmount?: string;
         isDevnet?: boolean;
     }) => (
-        <div className='w-full flex justify-between items-center'>
+        <div className='flex w-full items-center justify-between'>
             <AmountBadge
                 amount={renderAmount({
                     value,

--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -94,6 +94,7 @@ export const TransactionBody = ({
                 )}
 
                 <TrasactionItem title={t('COMMON.TRANSACTION_FEE')}>
+                    <div className='w-full flex justify-between items-center'>
                     {renderAmount({
                         value: transaction.fee(),
                         isNegative: false,
@@ -106,9 +107,10 @@ export const TransactionBody = ({
                                 value={convert(transaction.fee())}
                                 ticker={primaryWallet?.exchangeCurrency() ?? 'USD'}
                                 underlineOnHover={true}
-                            />
+                                />
                         </span>
                     )}
+                    </div>
                 </TrasactionItem>
 
                 {type === TransactionType.OTHER && (

--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -94,22 +94,22 @@ export const TransactionBody = ({
                 )}
 
                 <TrasactionItem title={t('COMMON.TRANSACTION_FEE')}>
-                    <div className='w-full flex justify-between items-center'>
-                    {renderAmount({
-                        value: transaction.fee(),
-                        isNegative: false,
-                        showSign: false,
-                        primaryCurrency: primaryWallet?.currency() ?? 'ARK',
-                    })}
-                    {!primaryWallet?.network().isTest() && (
-                        <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
-                            <Amount
-                                value={convert(transaction.fee())}
-                                ticker={primaryWallet?.exchangeCurrency() ?? 'USD'}
-                                underlineOnHover={true}
+                    <div className='flex w-full items-center justify-between'>
+                        {renderAmount({
+                            value: transaction.fee(),
+                            isNegative: false,
+                            showSign: false,
+                            primaryCurrency: primaryWallet?.currency() ?? 'ARK',
+                        })}
+                        {!primaryWallet?.network().isTest() && (
+                            <span className='text-theme-secondary-500 dark:text-theme-secondary-300'>
+                                <Amount
+                                    value={convert(transaction.fee())}
+                                    ticker={primaryWallet?.exchangeCurrency() ?? 'USD'}
+                                    underlineOnHover={true}
                                 />
-                        </span>
-                    )}
+                            </span>
+                        )}
                     </div>
                 </TrasactionItem>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[tx details] move fiat value to right](https://app.clickup.com/t/86dtdkybm)

## Summary

- Fiat values have been moved to the right.

<img width="360" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/8c8a2dca-5878-4103-b02f-0349607b70e5">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
