### PR TITLE
fix: improve small amount styling

### DIFF
--- a/src/components/wallet/Amount.tsx
+++ b/src/components/wallet/Amount.tsx
@@ -1,8 +1,8 @@
 import cn from 'classnames';
-import constants from '@/constants';
-import cropToMaxDigits from '@/lib/utils/cropToMaxDigits';
 import { Helpers } from '@ardenthq/sdk-profiles';
 import { TippyProps } from '@tippyjs/react';
+import constants from '@/constants';
+import cropToMaxDigits from '@/lib/utils/cropToMaxDigits';
 import { Tooltip } from '@/shared/components';
 
 interface AmountProperties {

--- a/src/components/wallet/Amount.tsx
+++ b/src/components/wallet/Amount.tsx
@@ -1,8 +1,8 @@
-import { Helpers } from '@ardenthq/sdk-profiles';
-import { TippyProps } from '@tippyjs/react';
 import cn from 'classnames';
 import constants from '@/constants';
 import cropToMaxDigits from '@/lib/utils/cropToMaxDigits';
+import { Helpers } from '@ardenthq/sdk-profiles';
+import { TippyProps } from '@tippyjs/react';
 import { Tooltip } from '@/shared/components';
 
 interface AmountProperties {
@@ -32,6 +32,7 @@ const Amount = ({
     displayTooltip = true,
     hideSmallValues = false,
 }: AmountProperties) => {
+    value = value / 100000;
     let actualFormattedAmount = Helpers.Currency.format(value, ticker, { withTicker });
     const valueToFormat = hideSmallValues && value !== 0 && value < 0.01 ? 0.01 : value;
 
@@ -44,7 +45,7 @@ const Amount = ({
     });
 
     if (valueToFormat !== value) {
-        formattedAmount = `< ${formattedAmount}`;
+        formattedAmount = ` <${formattedAmount}`; // Note: has a space before it to avoid "+<0.01"
     }
 
     if (value === 0 && !['ARK', 'DARK'].includes(formattedAmount.split(' ')[1])) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

fixes the styling of small amounts ( < 0.01) so they no longer show as `+< 0.01` but `+ <0.01` instead

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
