### PR TITLE
refactor: address dropdown behaviour

### DIFF
--- a/src/components/send/AddressDropdown.tsx
+++ b/src/components/send/AddressDropdown.tsx
@@ -158,6 +158,8 @@ export const AddressDropdown = () => {
                             onClick={() => {
                                 setInputValue(suggestion.address);
                                 setShowSuggestions(false);
+                                inputRef?.current?.click();
+                                inputRef?.current?.focus();
                             }}
                         >
                             <span className='text-base font-medium text-light-black dark:text-white'>

--- a/src/components/send/AddressDropdown.tsx
+++ b/src/components/send/AddressDropdown.tsx
@@ -156,10 +156,10 @@ export const AddressDropdown = () => {
                                 'flex w-full cursor-pointer flex-col gap-1 px-4 py-3 hover:bg-theme-secondary-50 dark:hover:bg-theme-secondary-700',
                             )}
                             onClick={() => {
-                                setInputValue(suggestion.address);
-                                setShowSuggestions(false);
                                 inputRef?.current?.click();
                                 inputRef?.current?.focus();
+                                setInputValue(suggestion.address);
+                                setShowSuggestions(false);
                             }}
                         >
                             <span className='text-base font-medium text-light-black dark:text-white'>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[send] additional modifications to the Recipient field](https://app.clickup.com/t/86dthrc7v)

## Summary

- We now focus on the input after the user selects a suggestions, preventing the display value to be shown unless we click outside of the address dropdown input.

<!-- What changes are being made? -->

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/51649d0e-666e-4058-b05c-0a84e1938081



<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
