### PR TITLE
refactor: display contacts per network

### DIFF
--- a/src/components/send/AddressDropdown.tsx
+++ b/src/components/send/AddressDropdown.tsx
@@ -28,7 +28,7 @@ export const AddressDropdown = () => {
     const wrapperRef = useRef<HTMLDivElement | null>(null);
     const inputRef = useRef<HTMLInputElement | null>(null);
     const [inputValue, setInputValue] = useState('');
-    const { addressBook } = useAddressBook();
+    const { filteredAddressBook: addressBook } = useAddressBook();
     const [showSuggestions, setShowSuggestions] = useState(false);
     const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(0);
     const [openModal, setOpenModal] = useState(false);

--- a/src/lib/hooks/useAddressBook.ts
+++ b/src/lib/hooks/useAddressBook.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { usePrimaryWallet } from './usePrimaryWallet';
 import { WalletNetwork } from '@/lib/store/wallet';
 
 export type Contact = {
@@ -8,6 +9,7 @@ export type Contact = {
 };
 
 const useAddressBook = () => {
+    const primaryWallet = usePrimaryWallet();
     const [addressBook, setAddressBook] = useState<Contact[]>([]);
 
     useEffect(() => {
@@ -48,11 +50,18 @@ const useAddressBook = () => {
         [addressBook],
     );
 
+    const filteredAddressBook = useMemo(
+        (): Contact[] =>
+            addressBook.filter((contact) => contact.type === (primaryWallet?.network().isTest() ? WalletNetwork.DEVNET : WalletNetwork.MAINNET)),
+        [addressBook, primaryWallet],
+    );
+
     return {
         addressBook,
         addContact,
         updateContact,
         removeContact,
+        filteredAddressBook,
     };
 };
 

--- a/src/lib/hooks/useAddressBook.ts
+++ b/src/lib/hooks/useAddressBook.ts
@@ -52,7 +52,13 @@ const useAddressBook = () => {
 
     const filteredAddressBook = useMemo(
         (): Contact[] =>
-            addressBook.filter((contact) => contact.type === (primaryWallet?.network().isTest() ? WalletNetwork.DEVNET : WalletNetwork.MAINNET)),
+            addressBook.filter(
+                (contact) =>
+                    contact.type ===
+                    (primaryWallet?.network().isTest()
+                        ? WalletNetwork.DEVNET
+                        : WalletNetwork.MAINNET),
+            ),
         [addressBook, primaryWallet],
     );
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[send] display contacts on the same network as sending address](https://app.clickup.com/t/86dtj2xre)

## Summary

- We now display the contacts filtered by the wallet's network on the address book dropdown.
- 
<img width="368" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/fa590bb8-1cc1-4a8b-9850-295b3fdb3259">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
