### PR TITLE
refactor: display contact name on approval pages

### DIFF
--- a/src/components/approve/ActionBody.blocks.tsx
+++ b/src/components/approve/ActionBody.blocks.tsx
@@ -133,7 +133,7 @@ export const ActionAddressRow = ({ label, address, displayAddressBookName = fals
                     'flex-col': !nameRef?.current?.clientWidth || nameRef.current.clientWidth > 100,
                     'flex-row gap-1': nameRef?.current?.clientWidth && nameRef.current.clientWidth <= 100,
                 })} id='container'>
-                    <span className='text-sm font-medium text-light-black dark:text-white w-fit' ref={nameRef}>{contact.name}</span>
+                    <span className='text-sm font-medium text-light-black dark:text-white w-fit text-right' ref={nameRef}>{contact.name}</span>
                     <div className='font-medium text-theme-secondary-500 text-sm dark:text-theme-secondary-300 flex flex-row justify-end'>
                     (<Address
                         address={address}

--- a/src/components/approve/ActionBody.blocks.tsx
+++ b/src/components/approve/ActionBody.blocks.tsx
@@ -1,4 +1,6 @@
 import { useTranslation } from 'react-i18next';
+import { useRef } from 'react';
+import cn from 'classnames';
 import { Address } from '../wallet/address/Address.blocks';
 import { ActionDetailsFiatValue, ActionDetailsRow } from './ActionDetails';
 import { ActionDetailsValue } from './ActionDetailsValue';
@@ -6,6 +8,7 @@ import { Icon, Tooltip } from '@/shared/components';
 import trimAddress from '@/lib/utils/trimAddress';
 import useClipboard from '@/lib/hooks/useClipboard';
 import Amount from '@/components/wallet/Amount';
+import useAddressBook from '@/lib/hooks/useAddressBook';
 
 interface ActionBodyRowProps {
     label: React.ReactNode;
@@ -114,7 +117,35 @@ export const ActionTransactionIdRow = ({ transactionId }: { transactionId: strin
     );
 };
 
-export const ActionAddressRow = ({ label, address }: { label: string; address: string }) => {
+export const ActionAddressRow = ({ label, address, displayAddressBookName = false }: { label: string; address: string, displayAddressBookName?: boolean }) => {
+    const { findContact } = useAddressBook();
+    const nameRef = useRef<HTMLSpanElement>(null);
+    let contact; 
+    
+    if (displayAddressBookName) {
+        contact = findContact(address);
+    }
+    
+    if (displayAddressBookName && contact) {
+        return (
+            <ActionDetailsRow label={label}>
+                <div className={cn('flex', {
+                    'flex-col': !nameRef?.current?.clientWidth || nameRef.current.clientWidth > 100,
+                    'flex-row gap-1': nameRef?.current?.clientWidth && nameRef.current.clientWidth <= 100,
+                })} id='container'>
+                    <span className='text-sm font-medium text-light-black dark:text-white w-fit' ref={nameRef}>{contact.name}</span>
+                    <div className='font-medium text-theme-secondary-500 text-sm dark:text-theme-secondary-300 flex flex-row justify-end'>
+                    (<Address
+                        address={address}
+                        tooltipPlacement='bottom-end'
+                        length={10}
+                        />)
+                    </div>
+                </div>
+            </ActionDetailsRow>
+        );
+    }
+
     return (
         <ActionDetailsRow label={label}>
             <Address

--- a/src/components/approve/ActionBody.blocks.tsx
+++ b/src/components/approve/ActionBody.blocks.tsx
@@ -117,29 +117,43 @@ export const ActionTransactionIdRow = ({ transactionId }: { transactionId: strin
     );
 };
 
-export const ActionAddressRow = ({ label, address, displayAddressBookName = false }: { label: string; address: string, displayAddressBookName?: boolean }) => {
+export const ActionAddressRow = ({
+    label,
+    address,
+    displayAddressBookName = false,
+}: {
+    label: string;
+    address: string;
+    displayAddressBookName?: boolean;
+}) => {
     const { findContact } = useAddressBook();
     const nameRef = useRef<HTMLSpanElement>(null);
-    let contact; 
-    
+    let contact;
+
     if (displayAddressBookName) {
         contact = findContact(address);
     }
-    
+
     if (displayAddressBookName && contact) {
         return (
             <ActionDetailsRow label={label}>
-                <div className={cn('flex', {
-                    'flex-col': !nameRef?.current?.clientWidth || nameRef.current.clientWidth > 100,
-                    'flex-row gap-1': nameRef?.current?.clientWidth && nameRef.current.clientWidth <= 100,
-                })} id='container'>
-                    <span className='text-sm font-medium text-light-black dark:text-white w-fit text-right' ref={nameRef}>{contact.name}</span>
-                    <div className='font-medium text-theme-secondary-500 text-sm dark:text-theme-secondary-300 flex flex-row justify-end'>
-                    (<Address
-                        address={address}
-                        tooltipPlacement='bottom-end'
-                        length={10}
-                        />)
+                <div
+                    className={cn('flex', {
+                        'flex-col':
+                            !nameRef?.current?.clientWidth || nameRef.current.clientWidth > 100,
+                        'flex-row gap-1':
+                            nameRef?.current?.clientWidth && nameRef.current.clientWidth <= 100,
+                    })}
+                    id='container'
+                >
+                    <span
+                        className='w-fit text-right text-sm font-medium text-light-black dark:text-white'
+                        ref={nameRef}
+                    >
+                        {contact.name}
+                    </span>
+                    <div className='flex flex-row justify-end text-sm font-medium text-theme-secondary-500 dark:text-theme-secondary-300'>
+                        (<Address address={address} tooltipPlacement='bottom-end' length={10} />)
                     </div>
                 </div>
             </ActionDetailsRow>

--- a/src/components/approve/ActionBody.tsx
+++ b/src/components/approve/ActionBody.tsx
@@ -78,7 +78,7 @@ export const ActionBody = ({
                 />
             )}
 
-            {receiver && <ActionAddressRow label={t('COMMON.RECEIVER')} address={receiver} />}
+            {receiver && <ActionAddressRow label={t('COMMON.RECEIVER')} address={receiver} displayAddressBookName />}
             {memo && (
                 <ActionBodyRow
                     label={t('COMMON.MEMO')}

--- a/src/components/approve/ActionBody.tsx
+++ b/src/components/approve/ActionBody.tsx
@@ -78,7 +78,13 @@ export const ActionBody = ({
                 />
             )}
 
-            {receiver && <ActionAddressRow label={t('COMMON.RECEIVER')} address={receiver} displayAddressBookName />}
+            {receiver && (
+                <ActionAddressRow
+                    label={t('COMMON.RECEIVER')}
+                    address={receiver}
+                    displayAddressBookName
+                />
+            )}
             {memo && (
                 <ActionBodyRow
                     label={t('COMMON.MEMO')}

--- a/src/lib/hooks/useAddressBook.ts
+++ b/src/lib/hooks/useAddressBook.ts
@@ -48,11 +48,19 @@ const useAddressBook = () => {
         [addressBook],
     );
 
+    const findContact = useCallback(
+        (address: string) => {
+            return addressBook.find((contact) => contact.address === address);
+        },
+        [addressBook],
+    );
+
     return {
         addressBook,
         addContact,
         updateContact,
         removeContact,
+        findContact,
     };
 };
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[send] display contact name on approval pages](https://app.clickup.com/t/86dtj5uwb)

## Summary

- Contact name is now displayed on approval pages for transfer actions.

## Screenshots

- Transaction Approval page:
<img width="370" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/20197718-aa08-4d9a-a690-0b66e49cc2b9">
- Approved Transaction page:
<img width="368" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/2e0d76e9-bedb-4264-8097-072affb5c335">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
