### PR TITLE
fix: validate address based on actual network

### DIFF
--- a/src/pages/CreateContact.tsx
+++ b/src/pages/CreateContact.tsx
@@ -4,41 +4,42 @@ import { Contracts } from '@ardenthq/sdk-profiles';
 import { useFormik } from 'formik';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Networks } from '@ardenthq/sdk';
 import { AddNewContactForm, SaveContactButton } from '@/components/address-book';
 import { ContactFormik, ValidateAddressResponse } from '@/components/address-book/types';
-import { Network, WalletNetwork } from '@/lib/store/wallet';
+import { WalletNetwork } from '@/lib/store/wallet';
 
 import constants from '@/constants';
 import SubPageLayout from '@/components/settings/SubPageLayout';
 import useAddressBook from '@/lib/hooks/useAddressBook';
 import { useProfileContext } from '@/lib/context/Profile';
 import useToast from '@/lib/hooks/useToast';
+import useActiveNetwork from '@/lib/hooks/useActiveNetwork';
 
 const COIN_ID = 'ARK';
 
 export const validateAddress = async ({
     address,
     profile,
+    network,
 }: {
     address?: string;
     profile: Contracts.IProfile;
+    network: Networks.Network;
 }): Promise<ValidateAddressResponse> => {
     try {
         if (address) {
-            for (const network of [Network.MAINNET, Network.DEVNET]) {
-                try {
-                    await profile.walletFactory().fromAddress({ address, coin: COIN_ID, network });
+            try {
+                await profile
+                    .walletFactory()
+                    .fromAddress({ address, coin: COIN_ID, network: network.id() });
 
-                    return {
-                        isValid: true,
-                        network:
-                            network === Network.MAINNET
-                                ? WalletNetwork.MAINNET
-                                : WalletNetwork.DEVNET,
-                    };
-                } catch {
-                    // Do nothing, it failed validation
-                }
+                return {
+                    isValid: true,
+                    network: network.id(),
+                };
+            } catch {
+                return { isValid: false, network: WalletNetwork.MAINNET };
             }
         }
         return { isValid: false, network: WalletNetwork.MAINNET };
@@ -58,6 +59,8 @@ const CreateContact = () => {
         isValid: false,
         network: WalletNetwork.MAINNET,
     });
+
+    const network = useActiveNetwork();
 
     const validationSchema = object().shape({
         name: string()
@@ -98,7 +101,11 @@ const CreateContact = () => {
 
     useEffect(() => {
         const handleAddressValidation = async () => {
-            const response = await validateAddress({ address: formik.values.address, profile });
+            const response = await validateAddress({
+                address: formik.values.address,
+                profile,
+                network,
+            });
             setAddressValidation(response);
         };
 

--- a/src/pages/EditContact.tsx
+++ b/src/pages/EditContact.tsx
@@ -13,7 +13,6 @@ import useAddressBook from '@/lib/hooks/useAddressBook';
 import { useProfileContext } from '@/lib/context/Profile';
 import useToast from '@/lib/hooks/useToast';
 import { WalletNetwork } from '@/lib/store/wallet';
-import useActiveNetwork from '@/lib/hooks/useActiveNetwork';
 
 const EditContact = () => {
     const toast = useToast();
@@ -27,7 +26,6 @@ const EditContact = () => {
         isValid: false,
         network: WalletNetwork.MAINNET,
     });
-    const network = useActiveNetwork();
 
     const validationSchema = object().shape({
         name: string()
@@ -69,11 +67,7 @@ const EditContact = () => {
 
     useEffect(() => {
         const handleAddressValidation = async () => {
-            const response = await validateAddress({
-                address: formik.values.address,
-                profile,
-                network,
-            });
+            const response = await validateAddress({ address: formik.values.address, profile });
             setAddressValidation(response);
         };
 

--- a/src/pages/EditContact.tsx
+++ b/src/pages/EditContact.tsx
@@ -13,6 +13,7 @@ import useAddressBook from '@/lib/hooks/useAddressBook';
 import { useProfileContext } from '@/lib/context/Profile';
 import useToast from '@/lib/hooks/useToast';
 import { WalletNetwork } from '@/lib/store/wallet';
+import useActiveNetwork from '@/lib/hooks/useActiveNetwork';
 
 const EditContact = () => {
     const toast = useToast();
@@ -26,6 +27,7 @@ const EditContact = () => {
         isValid: false,
         network: WalletNetwork.MAINNET,
     });
+    const network = useActiveNetwork();
 
     const validationSchema = object().shape({
         name: string()
@@ -67,7 +69,11 @@ const EditContact = () => {
 
     useEffect(() => {
         const handleAddressValidation = async () => {
-            const response = await validateAddress({ address: formik.values.address, profile });
+            const response = await validateAddress({
+                address: formik.values.address,
+                profile,
+                network,
+            });
             setAddressValidation(response);
         };
 

--- a/src/pages/EditContact.tsx
+++ b/src/pages/EditContact.tsx
@@ -68,7 +68,6 @@ const EditContact = () => {
     useEffect(() => {
         const handleAddressValidation = async () => {
             const response = await validateAddress({ address: formik.values.address, profile });
-            console.log({ response });
             setAddressValidation(response);
         };
 

--- a/src/pages/EditContact.tsx
+++ b/src/pages/EditContact.tsx
@@ -68,6 +68,7 @@ const EditContact = () => {
     useEffect(() => {
         const handleAddressValidation = async () => {
             const response = await validateAddress({ address: formik.values.address, profile });
+            console.log({ response });
             setAddressValidation(response);
         };
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[address book] adjust address validation](https://app.clickup.com/t/86dtjnfaq)

## Summary
Fixes the address validation in `AddressBook` to identify given address's network and validate it against it.


For testing:
* Click on settings 3-dot menu
* Go to Address book
* Click on Add contact
* Enter an address either devnet or mainnet, and click save
* It should create the new address and properly assign the network indicator icon (`T` for devnet, and no icon for mainnet). 

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
