### PR TITLE
refactor: add border and do not inverse qr code colors in dark mode

### DIFF
--- a/src/components/receive/QRCodeContainer.tsx
+++ b/src/components/receive/QRCodeContainer.tsx
@@ -3,7 +3,6 @@ import QRCode from 'react-qr-code';
 import { useState } from 'react';
 import { useFormik } from 'formik';
 import { object, string } from 'yup';
-import useThemeMode from '@/lib/hooks/useThemeMode';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
 import { generateReceiveUrl } from '@/lib/utils/generateReceiveURL';
 import { Accordion, Input } from '@/shared/components';
@@ -16,7 +15,6 @@ export type SendFormik = {
 export const QRCodeContainer = () => {
     const primaryWallet = usePrimaryWallet();
     const { t } = useTranslation();
-    const { isDark } = useThemeMode();
 
     const [isOpen, setIsOpen] = useState(false);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[receive] add border to QR code for a more reliable scan](https://app.clickup.com/t/86dtjwppp)

## Summary

- We now display a border in dark mode for our QR code in `Receive` page. This will help the codes to be easily readable by cameras while using dark mode in the extension.

<img width="371" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/b2f53453-22e3-4bef-a52b-e86143356b00">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
