### PR TITLE
fix: max value button

### DIFF
--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -12,8 +12,9 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
     const { t } = useTranslation();
 
     const handleMaxClick = () => {
-        const balance = primaryWallet?.balance() || 0;
-        const maxValue = balance !== 0 ? balance - Number(formik.values.fee) : 0;
+        const balance = primaryWallet?.balance() ?? 0;
+        const fee = Number(formik.values.fee);
+        const maxValue = Math.max(0, balance - fee);
         formik.setFieldValue('amount', maxValue);
     };
 

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -71,7 +71,9 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
                 value={formik.values.amount}
                 onChange={handleInputChange}
                 onBlur={formik.handleBlur}
-                variant={formik.errors.amount && formik.values.amount !== '' ? 'destructive' : 'primary'}
+                variant={
+                    formik.errors.amount && formik.values.amount !== '' ? 'destructive' : 'primary'
+                }
                 autoComplete='off'
                 helperText={formik.values.amount !== '' ? formik.errors.amount : undefined}
             />

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -21,6 +21,7 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
     const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         event.target.value = event.target.value.trim();
         formik.handleChange(event);
+        formik.validateField('amount');
     };
 
     return (
@@ -70,9 +71,9 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
                 value={formik.values.amount}
                 onChange={handleInputChange}
                 onBlur={formik.handleBlur}
-                variant={formik.errors.amount && formik.values.amount ? 'destructive' : 'primary'}
+                variant={formik.errors.amount && formik.values.amount !== '' ? 'destructive' : 'primary'}
                 autoComplete='off'
-                helperText={formik.values.amount ? formik.errors.amount : undefined}
+                helperText={formik.values.amount !== '' ? formik.errors.amount : undefined}
             />
 
             <Input

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -50,6 +50,13 @@ const Send = () => {
                     return sum <= userBalance;
                 },
             )
+            .test(
+                'min-value',
+                t('ERROR.IS_REQUIRED', { name: 'Amount' }),
+                (value) => {
+                    return Number(value) > 0;
+                },
+            )
             .trim(),
         memo: string().max(255, t('ERROR.IS_TOO_LONG', { name: 'Memo' })),
         fee: string()

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -50,13 +50,6 @@ const Send = () => {
                     return sum <= userBalance;
                 },
             )
-            .test(
-                'min-value',
-                t('ERROR.IS_REQUIRED', { name: 'Amount' }),
-                (value) => {
-                    return Number(value) > 0;
-                },
-            )
             .trim(),
         memo: string().max(255, t('ERROR.IS_TOO_LONG', { name: 'Memo' })),
         fee: string()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[send] Amount "Max" button can provide negative number](https://app.clickup.com/t/86dtk8e3n)

## Summary

- `Amount` input field is validated after clicking the `MAX` button.
- We now prevent this button to set a negative value if the fee exceeds the balance.

<!-- What changes are being made? -->

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/26110667-a8cc-4bce-a68e-785bf0da8986



<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
