### PR TITLE
refactor: display tooltip on send page if balance > 0

### DIFF
--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -51,7 +51,7 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
                             showSign={false}
                             isNegative={false}
                             maxDigits={20}
-                            displayTooltip={primaryWallet && primaryWallet.balance() <= 0.01}
+                            displayTooltip={primaryWallet && primaryWallet.balance() > 0}
                             maxDecimals={2}
                             hideSmallValues
                         />

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -1,11 +1,11 @@
+import { FormikProps } from 'formik';
+import { useTranslation } from 'react-i18next';
 import { AddressDropdown } from '@/components/send/AddressDropdown';
 import Amount from '@/components/wallet/Amount';
 import { FeeSection } from '@/components/fees';
-import { FormikProps } from 'formik';
 import { Input } from '@/shared/components';
 import { SendFormik } from '@/pages/Send';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
-import { useTranslation } from 'react-i18next';
 
 export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
     const primaryWallet = usePrimaryWallet();

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -1,11 +1,11 @@
-import { useTranslation } from 'react-i18next';
-import { FormikProps } from 'formik';
-import { FeeSection } from '@/components/fees';
-import Amount from '@/components/wallet/Amount';
-import { Input } from '@/shared/components';
-import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
-import { SendFormik } from '@/pages/Send';
 import { AddressDropdown } from '@/components/send/AddressDropdown';
+import Amount from '@/components/wallet/Amount';
+import { FeeSection } from '@/components/fees';
+import { FormikProps } from 'formik';
+import { Input } from '@/shared/components';
+import { SendFormik } from '@/pages/Send';
+import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
+import { useTranslation } from 'react-i18next';
 
 export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
     const primaryWallet = usePrimaryWallet();
@@ -51,7 +51,7 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
                             showSign={false}
                             isNegative={false}
                             maxDigits={20}
-                            displayTooltip={primaryWallet && primaryWallet.balance() > 0.1}
+                            displayTooltip={primaryWallet && primaryWallet.balance() <= 0.01}
                             maxDecimals={2}
                             hideSmallValues
                         />

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -44,17 +44,17 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
                 secondaryText={
                     <span>
                         {`${t('COMMON.AVAILABLE')}: `}
-                            <Amount
-                                value={primaryWallet?.balance() ?? 0}
-                                ticker={primaryWallet?.currency() || 'ARK'}
-                                withTicker
-                                showSign={false}
-                                isNegative={false}
-                                maxDigits={20}
-                                displayTooltip={primaryWallet && primaryWallet.balance() > 0.1}
-                                maxDecimals={2}
-                                hideSmallValues
-                            />
+                        <Amount
+                            value={primaryWallet?.balance() ?? 0}
+                            ticker={primaryWallet?.currency() || 'ARK'}
+                            withTicker
+                            showSign={false}
+                            isNegative={false}
+                            maxDigits={20}
+                            displayTooltip={primaryWallet && primaryWallet.balance() > 0.1}
+                            maxDecimals={2}
+                            hideSmallValues
+                        />
                     </span>
                 }
                 placeholder={t('COMMON.ENTER_AMOUNT')}

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -44,17 +44,17 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
                 secondaryText={
                     <span>
                         {`${t('COMMON.AVAILABLE')}: `}
-                        <Amount
-                            value={primaryWallet?.balance() || 0}
-                            ticker={primaryWallet?.currency() || 'ARK'}
-                            withTicker
-                            showSign={false}
-                            isNegative={false}
-                            maxDigits={20}
-                            displayTooltip={false}
-                            maxDecimals={2}
-                            hideSmallValues
-                        />
+                            <Amount
+                                value={primaryWallet?.balance() ?? 0}
+                                ticker={primaryWallet?.currency() || 'ARK'}
+                                withTicker
+                                showSign={false}
+                                isNegative={false}
+                                maxDigits={20}
+                                displayTooltip={primaryWallet && primaryWallet.balance() > 0.1}
+                                maxDecimals={2}
+                                hideSmallValues
+                            />
                     </span>
                 }
                 placeholder={t('COMMON.ENTER_AMOUNT')}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[Send] display full balance in tooltip if <0.01](https://app.clickup.com/t/86dtk8e55)

## Summary

- We now display the tooltip with the total amount if the balance is above `0 ARK/DARK`.

<img width="375" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/0ca031c2-1422-461b-aed9-79dcc2c28698">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
