### PR TITLE
refactor: hide suggestions after pasting address on send page

### DIFF
--- a/src/components/send/AddressDropdown.tsx
+++ b/src/components/send/AddressDropdown.tsx
@@ -123,7 +123,7 @@ export const AddressDropdown = ({
         setValue(address);
         setOpenModal(false);
     };
-    
+
     const handlePaste = (event: React.ClipboardEvent) => {
         const pastedValue = event.clipboardData.getData('text');
         if (pastedValue.length === constants.ADDRESS_LENGTH) {

--- a/src/components/send/AddressDropdown.tsx
+++ b/src/components/send/AddressDropdown.tsx
@@ -15,6 +15,7 @@ type AddressDropdownProps = ComponentPropsWithRef<'input'> & {
     helperText?: string;
     value?: string;
     setValue: (value: string) => void;
+    handleValidation: () => void;
 };
 
 const AddressBookButton = ({ onClick }: { onClick: () => void }) => {
@@ -35,6 +36,7 @@ export const AddressDropdown = ({
     helperText,
     value,
     setValue,
+    handleValidation,
     ...rest
 }: AddressDropdownProps) => {
     const { t } = useTranslation();
@@ -121,11 +123,12 @@ export const AddressDropdown = ({
         setValue(address);
         setOpenModal(false);
     };
-
+    
     const handlePaste = (event: React.ClipboardEvent) => {
         const pastedValue = event.clipboardData.getData('text');
         if (pastedValue.length === constants.ADDRESS_LENGTH) {
             setShowSuggestions(false);
+            handleValidation();
         }
     };
 

--- a/src/components/send/AddressDropdown.tsx
+++ b/src/components/send/AddressDropdown.tsx
@@ -122,6 +122,13 @@ export const AddressDropdown = ({
         setOpenModal(false);
     };
 
+    const handlePaste = (event: React.ClipboardEvent) => {
+        const pastedValue = event.clipboardData.getData('text');
+        if (pastedValue.length === constants.ADDRESS_LENGTH) {
+            setShowSuggestions(false);
+        }
+    };
+
     return (
         <div className='relative' ref={wrapperRef}>
             <Input
@@ -143,6 +150,7 @@ export const AddressDropdown = ({
                 variant={variant}
                 helperText={helperText}
                 autoComplete='off'
+                onPaste={handlePaste}
                 {...rest}
             />
             {showSuggestions && suggestions.length > 0 && (

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -22,6 +22,10 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
         formik.handleChange(event);
     };
 
+    const handleValidation = () => {
+        formik.validateField('receiverAddress');
+    };
+
     return (
         <div className='flex flex-col gap-4'>
             <AddressDropdown
@@ -37,6 +41,7 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
                 }
                 value={formik.values.receiverAddress}
                 setValue={(value: string) => formik.setFieldValue('receiverAddress', value)}
+                handleValidation={handleValidation}
             />
             <Input
                 name='amount'

--- a/src/i18n/ns/error.ts
+++ b/src/i18n/ns/error.ts
@@ -2,6 +2,8 @@ export default {
     BALANCE_TOO_LOW: 'Balance too low',
     IS_DUPLICATED: 'This {{name}} already exists',
     IS_INVALID: 'Invalid {{name}}',
+    IS_INVALID_ADDRESS_LENGTH: 'Invalid address length',
+    IS_INVALID_NETWORK: 'Invalid network',
     IS_TOO_HIGH: '{{name}} is too high',
     IS_TOO_LONG: '{{name}} is too long',
     IS_REQUIRED: '{{name}} is required',

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -1,16 +1,16 @@
 import { object, string } from 'yup';
-import { SendButton, SendForm } from '@/components/send';
 import { useEffect, useState } from 'react';
 
 import { BigNumber } from '@ardenthq/sdk-helpers';
-import constants from '@/constants';
-import SubPageLayout from '@/components/settings/SubPageLayout';
 import { useFormik } from 'formik';
 import { useNavigate } from 'react-router-dom';
-import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
-import { useProfileContext } from '@/lib/context/Profile';
 import { useTranslation } from 'react-i18next';
 import { validateAddress } from './CreateContact';
+import constants from '@/constants';
+import SubPageLayout from '@/components/settings/SubPageLayout';
+import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
+import { useProfileContext } from '@/lib/context/Profile';
+import { SendButton, SendForm } from '@/components/send';
 import { ValidateAddressResponse } from '@/components/address-book/types';
 import { WalletNetwork } from '@/lib/store/wallet';
 

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -1,16 +1,16 @@
 import { object, string } from 'yup';
+import { SendButton, SendForm } from '@/components/send';
 import { useEffect, useState } from 'react';
 
 import { BigNumber } from '@ardenthq/sdk-helpers';
-import { useFormik } from 'formik';
-import { useNavigate } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
-import { validateAddress } from './CreateContact';
 import constants from '@/constants';
 import SubPageLayout from '@/components/settings/SubPageLayout';
+import { useFormik } from 'formik';
+import { useNavigate } from 'react-router-dom';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
 import { useProfileContext } from '@/lib/context/Profile';
-import { SendButton, SendForm } from '@/components/send';
+import { useTranslation } from 'react-i18next';
+import { validateAddress } from './CreateContact';
 import { ValidateAddressResponse } from '@/components/address-book/types';
 import { WalletNetwork } from '@/lib/store/wallet';
 
@@ -71,21 +71,31 @@ const Send = () => {
             .trim(),
         receiverAddress: string()
             .required(t('ERROR.IS_REQUIRED', { name: 'Address' }))
-            .min(constants.ADDRESS_LENGTH, t('ERROR.IS_INVALID' + 'a3', { name: 'Address' }))
-            .max(constants.ADDRESS_LENGTH, t('ERROR.IS_INVALID' + 'a4', { name: 'Address' }))
-            .test('valid-address', t('ERROR.IS_INVALID' + 'a1', { name: 'Address' }), () => {
+            .min(
+                constants.ADDRESS_LENGTH,
+                t('ERROR.IS_INVALID_ADDRESS_LENGTH', { name: 'Address' }),
+            )
+            .max(
+                constants.ADDRESS_LENGTH,
+                t('ERROR.IS_INVALID_ADDRESS_LENGTH', { name: 'Address' }),
+            )
+            .test('valid-address', t('ERROR.IS_INVALID', { name: 'Address' }), () => {
                 if (isLoading) return true;
                 return addressValidation.isValid;
             })
-            .test('same-network-address', t('ERROR.IS_INVALID' + 'a2', { name: 'Address' }), () => {
-                if (isLoading) return true;
-                return (
-                    addressValidation.network ===
-                    (primaryWallet?.network().isTest()
-                        ? WalletNetwork.DEVNET
-                        : WalletNetwork.MAINNET)
-                );
-            })
+            .test(
+                'same-network-address',
+                t('ERROR.IS_INVALID_NETWORK', { name: 'Address' }),
+                () => {
+                    if (isLoading) return true;
+                    return (
+                        addressValidation.network ===
+                        (primaryWallet?.network().isTest()
+                            ? WalletNetwork.DEVNET
+                            : WalletNetwork.MAINNET)
+                    );
+                },
+            )
             .trim(),
     });
 

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -24,6 +24,7 @@ const Send = () => {
     const primaryWallet = usePrimaryWallet();
     const { t } = useTranslation();
     const { profile } = useProfileContext();
+    const [isLoading, setIsLoading] = useState<boolean>(false);
     const [addressValidation, setAddressValidation] = useState<ValidateAddressResponse>({
         isValid: false,
         network: WalletNetwork.MAINNET,
@@ -66,12 +67,14 @@ const Send = () => {
             .trim(),
         receiverAddress: string()
             .required(t('ERROR.IS_REQUIRED', { name: 'Address' }))
-            .min(constants.ADDRESS_LENGTH, t('ERROR.IS_INVALID', { name: 'Address' }))
-            .max(constants.ADDRESS_LENGTH, t('ERROR.IS_INVALID', { name: 'Address' }))
-            .test('valid-address', t('ERROR.IS_INVALID', { name: 'Address' }), () => {
+            .min(constants.ADDRESS_LENGTH, t('ERROR.IS_INVALID' + 'a3', { name: 'Address' }))
+            .max(constants.ADDRESS_LENGTH, t('ERROR.IS_INVALID' + 'a4', { name: 'Address' }))
+            .test('valid-address', t('ERROR.IS_INVALID' + 'a1', { name: 'Address' }), () => {
+                if (isLoading) return true;
                 return addressValidation.isValid;
             })
-            .test('same-network-address', t('ERROR.IS_INVALID', { name: 'Address' }), () => {
+            .test('same-network-address', t('ERROR.IS_INVALID' + 'a2', { name: 'Address' }), () => {
+                if (isLoading) return true;
                 return (
                     addressValidation.network ===
                     (primaryWallet?.network().isTest()
@@ -81,7 +84,7 @@ const Send = () => {
             })
             .trim(),
     });
-
+    
     const formik = useFormik<SendFormik>({
         initialValues: {
             amount: '',
@@ -109,12 +112,15 @@ const Send = () => {
     });
 
     useEffect(() => {
+        setIsLoading(true);
+
         const handleAddressValidation = async () => {
             const response = await validateAddress({
                 address: formik.values.receiverAddress,
                 profile,
             });
             setAddressValidation(response);
+            setIsLoading(false);
         };
 
         if (
@@ -124,7 +130,7 @@ const Send = () => {
             handleAddressValidation();
         }
     }, [formik.values.receiverAddress, profile]);
-
+    
     return (
         <SubPageLayout title={t('COMMON.SEND')} className='relative p-0'>
             <div className='custom-scroll h-[393px] w-full overflow-y-auto px-4'>

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -84,7 +84,7 @@ const Send = () => {
             })
             .trim(),
     });
-    
+
     const formik = useFormik<SendFormik>({
         initialValues: {
             amount: '',
@@ -130,7 +130,7 @@ const Send = () => {
             handleAddressValidation();
         }
     }, [formik.values.receiverAddress, profile]);
-    
+
     return (
         <SubPageLayout title={t('COMMON.SEND')} className='relative p-0'>
             <div className='custom-scroll h-[393px] w-full overflow-y-auto px-4'>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[send] close dropdown when address is pasted in recipient field](https://app.clickup.com/t/86dtk0m72)

## Summary

- An `isLoading` state has been added for address validation. This will prevent displaying errors while it is still loading. 
- Address dropdown hides the suggestions after pasting a 34-character long value.


<!-- What changes are being made? -->

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/56a45665-12eb-41cd-89d9-65056f4b2693


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
