### PR TITLE
fix: display correct transaction fee in approval pages

### DIFF
--- a/src/components/ledger/ApproveWithLedger.blocks.tsx
+++ b/src/components/ledger/ApproveWithLedger.blocks.tsx
@@ -91,7 +91,7 @@ export const TransactionLedgerApprovalBody = ({ wallet, state }: Props) => {
         amount,
         receiverAddress,
         memo,
-        customFee
+        customFee,
     });
 
     return (

--- a/src/components/ledger/ApproveWithLedger.blocks.tsx
+++ b/src/components/ledger/ApproveWithLedger.blocks.tsx
@@ -24,6 +24,7 @@ interface Props {
         unvote: VoteDelegateProperties;
         tabId: number;
         memo?: string;
+        fee?: number;
     };
 }
 
@@ -74,7 +75,7 @@ export const VoteLedgerApprovalBody = ({ wallet, state }: Props) => {
 };
 
 export const TransactionLedgerApprovalBody = ({ wallet, state }: Props) => {
-    const { session, amount, receiverAddress, memo } = state;
+    const { session, amount, receiverAddress, memo, fee: customFee } = state;
     const { convert } = useExchangeRate({
         exchangeTicker: wallet.exchangeCurrency(),
         ticker: wallet.currency(),
@@ -90,6 +91,7 @@ export const TransactionLedgerApprovalBody = ({ wallet, state }: Props) => {
         amount,
         receiverAddress,
         memo,
+        customFee
     });
 
     return (


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[ledger] correct transaction fee isn't displayed on ledger approval page](https://app.clickup.com/t/86dtk0cbg)

## Summary

- `customFee` is now being passed as part of the state in `useSendTransferForm`. This will allow the custom fee to be considered in case it is passed.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/a2513f7a-6b92-4d52-999a-1e933a7aa5b7


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
