### PR TITLE
fix: avoid double scrollbars when address dropdown is open

### DIFF
--- a/src/components/send/AddressDropdown.tsx
+++ b/src/components/send/AddressDropdown.tsx
@@ -1,14 +1,14 @@
 import { ComponentPropsWithRef, useEffect, useMemo, useRef, useState } from 'react';
 
-import cn from 'classnames';
-import { useTranslation } from 'react-i18next';
 import { AddressBookModal } from './AddressBookModal';
+import cn from 'classnames';
 import constants from '@/constants';
 import { Input } from '@/shared/components';
 import Modal from '@/shared/components/modal/Modal';
 import trimAddress from '@/lib/utils/trimAddress';
 import useAddressBook from '@/lib/hooks/useAddressBook';
 import useOnClickOutside from '@/lib/hooks/useOnClickOutside';
+import { useTranslation } from 'react-i18next';
 
 type AddressDropdownProps = ComponentPropsWithRef<'input'> & {
     variant: 'primary' | 'destructive';
@@ -148,7 +148,7 @@ export const AddressDropdown = ({
             {showSuggestions && suggestions.length > 0 && (
                 <div
                     className={cn(
-                        'transition-smoothEase custom-scroll absolute z-10 mt-1 max-h-80 w-full overflow-auto rounded-lg bg-white py-2 shadow-lg dark:bg-subtle-black',
+                        'transition-smoothEase custom-scroll absolute z-10 mt-1 w-full overflow-auto rounded-lg bg-white py-2 shadow-lg dark:bg-subtle-black',
                         {
                             'max-h-72': showSuggestions,
                             'h-0': !showSuggestions,

--- a/src/components/send/AddressDropdown.tsx
+++ b/src/components/send/AddressDropdown.tsx
@@ -1,14 +1,14 @@
 import { ComponentPropsWithRef, useEffect, useMemo, useRef, useState } from 'react';
 
-import { AddressBookModal } from './AddressBookModal';
 import cn from 'classnames';
+import { useTranslation } from 'react-i18next';
+import { AddressBookModal } from './AddressBookModal';
 import constants from '@/constants';
 import { Input } from '@/shared/components';
 import Modal from '@/shared/components/modal/Modal';
 import trimAddress from '@/lib/utils/trimAddress';
 import useAddressBook from '@/lib/hooks/useAddressBook';
 import useOnClickOutside from '@/lib/hooks/useOnClickOutside';
-import { useTranslation } from 'react-i18next';
 
 type AddressDropdownProps = ComponentPropsWithRef<'input'> & {
     variant: 'primary' | 'destructive';


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dtkm86k

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
