### PR TITLE
fix: center input placeholder placement

### DIFF
--- a/src/shared/components/input/Input.tsx
+++ b/src/shared/components/input/Input.tsx
@@ -63,7 +63,7 @@ export const Input = ({
             >
                 {!focused && displayValue && (
                     <span
-                        className='absolute left-3 top-4 cursor-text'
+                        className='absolute left-3 top-3.5 cursor-text'
                         onClick={() => {
                             innerRef?.current?.click();
                             innerRef?.current?.focus();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

slightly moves the value up so it's in line with the input text

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
