### PR TITLE
refactor: display copy address button in address book

### DIFF
--- a/src/components/address-book/AddressBookList.tsx
+++ b/src/components/address-book/AddressBookList.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { ToastPosition } from '../toast/ToastContainer';
 import { TestnetIcon } from '@/components/wallet/address/Address.blocks';
 import { Contact } from '@/lib/hooks/useAddressBook';
 import { WalletNetwork } from '@/lib/store/wallet';
 import trimAddress from '@/lib/utils/trimAddress';
-import { IconButton, Tooltip } from '@/shared/components';
+import { Icon, IconButton, Tooltip } from '@/shared/components';
+import useClipboard from '@/lib/hooks/useClipboard';
 
 const AddressBookItem = ({
     name,
@@ -19,6 +21,7 @@ const AddressBookItem = ({
 }) => {
     const navigate = useNavigate();
     const nameRef = useRef<HTMLSpanElement>(null);
+    const { copy } = useClipboard();
     const [displayTooltip, setDisplayTooltip] = useState<boolean>(false);
 
     useEffect(() => {
@@ -33,6 +36,7 @@ const AddressBookItem = ({
         }
     }, [name]);
 
+    const trimmedAddress = trimAddress(address, 10);
     return (
         <div className='transition-smoothEase flex w-full flex-row items-center justify-between px-4 py-3 hover:bg-theme-secondary-50 dark:hover:bg-theme-secondary-700'>
             <div className='flex flex-col gap-1'>
@@ -48,8 +52,15 @@ const AddressBookItem = ({
                     {network === WalletNetwork.DEVNET && <TestnetIcon />}
                 </div>
                 <Tooltip content={<span>{address}</span>}>
-                    <span className='cursor-default text-sm font-normal text-theme-secondary-500 dark:text-theme-secondary-300'>
-                        {trimAddress(address, 10)}
+                    <span className='cursor-default text-sm font-normal text-theme-secondary-500 dark:text-theme-secondary-300 flex flex-row gap-0.5'>
+                        {trimmedAddress}
+                        <span className='h-5 w-5 flex items-center justify-center cursor-pointer' 
+                        onClick={() => {
+                            copy(address, trimmedAddress, ToastPosition.LOWER);
+                        }}
+                        >
+                            <Icon icon='copy' className='h-[13px] w-[13px]' />
+                        </span>
                     </span>
                 </Tooltip>
             </div>

--- a/src/components/address-book/AddressBookList.tsx
+++ b/src/components/address-book/AddressBookList.tsx
@@ -52,12 +52,13 @@ const AddressBookItem = ({
                     {network === WalletNetwork.DEVNET && <TestnetIcon />}
                 </div>
                 <Tooltip content={<span>{address}</span>}>
-                    <span className='cursor-default text-sm font-normal text-theme-secondary-500 dark:text-theme-secondary-300 flex flex-row gap-0.5'>
+                    <span className='flex cursor-default flex-row gap-0.5 text-sm font-normal text-theme-secondary-500 dark:text-theme-secondary-300'>
                         {trimmedAddress}
-                        <span className='h-5 w-5 flex items-center justify-center cursor-pointer' 
-                        onClick={() => {
-                            copy(address, trimmedAddress, ToastPosition.LOWER);
-                        }}
+                        <span
+                            className='flex h-5 w-5 cursor-pointer items-center justify-center'
+                            onClick={() => {
+                                copy(address, trimmedAddress, ToastPosition.LOWER);
+                            }}
                         >
                             <Icon icon='copy' className='h-[13px] w-[13px]' />
                         </span>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[address book] Add 'copy' function to addresses](https://app.clickup.com/t/86dtkz4n8)

## Summary

- Copy button has been added to address book items.

<img width="362" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/d4ded477-6677-4df1-8996-1d5673768de8">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
