### PR TITLE
fix: align address book suggestions

### DIFF
--- a/src/components/send/AddressDropdown.tsx
+++ b/src/components/send/AddressDropdown.tsx
@@ -171,7 +171,7 @@ export const AddressDropdown = ({
                         <button
                             key={index}
                             className={cn(
-                                'flex w-full cursor-pointer flex-col gap-1 px-4 py-3 hover:bg-theme-secondary-50 dark:hover:bg-theme-secondary-700 items-start',
+                                'flex w-full cursor-pointer flex-col items-start gap-1 px-4 py-3 hover:bg-theme-secondary-50 dark:hover:bg-theme-secondary-700',
                             )}
                             onClick={() => {
                                 inputRef?.current?.click();

--- a/src/components/send/AddressDropdown.tsx
+++ b/src/components/send/AddressDropdown.tsx
@@ -171,7 +171,7 @@ export const AddressDropdown = ({
                         <button
                             key={index}
                             className={cn(
-                                'flex w-full cursor-pointer flex-col gap-1 px-4 py-3 hover:bg-theme-secondary-50 dark:hover:bg-theme-secondary-700',
+                                'flex w-full cursor-pointer flex-col gap-1 px-4 py-3 hover:bg-theme-secondary-50 dark:hover:bg-theme-secondary-700 items-start',
                             )}
                             onClick={() => {
                                 inputRef?.current?.click();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[send] recipient dropdown centered text firefox](https://app.clickup.com/t/86dtkycna)

## Summary

- Address book suggestions have been aligned correctly in Firefox.

<img width="364" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/9da7ea4c-3c2d-46b6-84f7-64be2e5137a4">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
