### PR TITLE
fix: form resizes on errors

### DIFF
--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -35,7 +35,7 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
     };
 
     return (
-        <div className='flex flex-col gap-4'>
+        <div className='flex flex-col gap-4 w-[338px]'>
             <AddressDropdown
                 onChange={handleInputChange}
                 onBlur={formik.handleBlur}

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -35,7 +35,7 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
     };
 
     return (
-        <div className='flex flex-col gap-4 w-[338px]'>
+        <div className='flex w-[338px] flex-col gap-4'>
             <AddressDropdown
                 onChange={handleInputChange}
                 onBlur={formik.handleBlur}

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -149,7 +149,7 @@ const Send = () => {
 
     return (
         <SubPageLayout title={t('COMMON.SEND')} className='relative p-0'>
-            <div className='custom-scroll h-[393px] w-full overflow-y-auto px-4'>
+            <div className='custom-scroll h-[393px] w-full overflow-y-auto overflow-x-hidden px-4'>
                 <SendForm formik={formik} />
             </div>
             <div className='w-full'>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[send] form resizes when an error message is displayed](https://app.clickup.com/t/86dtkyu79)

## Summary

- An specific width for the form has been set, preventing the form to resize when having errors.

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/3e89004c-7104-480e-bf2e-59f0f0ba70e4



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
