### PR TITLE
refactor: persist approval page

### DIFF
--- a/src/pages/Approve.tsx
+++ b/src/pages/Approve.tsx
@@ -18,6 +18,7 @@ import { assertIsUnlocked } from '@/lib/background/assertions';
 import useWalletSync from '@/lib/hooks/useWalletSync';
 import { useEnvironmentContext } from '@/lib/context/Environment';
 import useLoadingModal from '@/lib/hooks/useLoadingModal';
+import { ScreenName } from '@/lib/background/contracts';
 
 export enum ApproveActionType {
     SIGNATURE = 'signature',
@@ -95,6 +96,19 @@ const Approve = () => {
                 return actionType;
         }
     };
+
+    useEffect(() => {
+        if(location.state?.type === ApproveActionType.TRANSACTION) {
+            profile.settings().set('LAST_VISITED_PAGE', {
+                path: ScreenName.SendTransfer,
+                data: location.state,
+            });
+        }
+
+        return () => {
+            profile.settings().forget('LAST_VISITED_PAGE');
+        };
+    }, [location]);
 
     return (
         <Layout withHeader={false}>

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -23,12 +23,35 @@ export type SendFormik = {
     receiverAddress: string;
 };
 
+interface PageData extends SendFormik {
+    type?: string;
+    session?:  {
+        walletId: string;
+        logo: string;
+        domain: string;
+    } 
+}
+
 const Send = () => {
     const navigate = useNavigate();
     const primaryWallet = usePrimaryWallet();
     const { t } = useTranslation();
     const { profile } = useProfileContext();
-    const lastVisitedPage = profile.settings().get('LAST_VISITED_PAGE') as { data: SendFormik };
+    const lastVisitedPage = profile.settings().get('LAST_VISITED_PAGE') as { data: PageData };
+    
+    if (lastVisitedPage?.data && lastVisitedPage.data.type === 'transfer') {
+        navigate('/approve', {
+            state: {
+                type: 'transfer',
+                amount: Number(lastVisitedPage.data.amount),
+                memo: lastVisitedPage.data.memo,
+                fee: Number(lastVisitedPage.data.fee),
+                receiverAddress: lastVisitedPage.data.receiverAddress,
+                session: lastVisitedPage.data.session,
+            },
+        });
+    }
+
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [addressValidation, setAddressValidation] = useState<ValidateAddressResponse>({
         isValid: false,

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -39,7 +39,7 @@ const Send = () => {
     const { profile } = useProfileContext();
     const lastVisitedPage = profile.settings().get('LAST_VISITED_PAGE') as { data: PageData };
     
-    if (lastVisitedPage?.data && lastVisitedPage.data.type === 'transfer') {
+    if (lastVisitedPage?.data && lastVisitedPage.data.type === 'transfer' && lastVisitedPage.data.session) {
         navigate('/approve', {
             state: {
                 type: 'transfer',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[address book] persist data on the approval page](https://app.clickup.com/t/86dtmeku7)

## Summary

- We now persist data on approval page for transfers only.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/361c6539-8bd4-48b3-88e1-c791210dfb39


<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
