### PR TITLE
fix: emit primary address change from background

### DIFF
--- a/src/OneTimeEventHandlers.ts
+++ b/src/OneTimeEventHandlers.ts
@@ -7,7 +7,6 @@ import { importWallets } from '@/background.helpers';
 import { EnvironmentData, ProfileData } from '@/lib/background/contracts';
 import { SendTransferInput } from '@/lib/background/extension.wallet';
 import { SessionEntries } from '@/lib/store/session';
-import { PrimaryWallet } from './lib/background/extension.wallet.primary';
 
 export enum OneTimeEvents {
     SEND_VOTE = 'SEND_VOTE',

--- a/src/lib/background/extension.wallet.ts
+++ b/src/lib/background/extension.wallet.ts
@@ -1,5 +1,5 @@
 import { Contracts } from '@ardenthq/sdk-profiles';
-import { Contracts as SDKContracts, Services } from '@ardenthq/sdk';
+import { Networks, Contracts as SDKContracts, Services } from '@ardenthq/sdk';
 import { buildTransferData } from '@/lib/utils/transactionHelpers';
 
 interface RecipientItem {
@@ -116,6 +116,22 @@ export function Wallet({ wallet }: { wallet: Contracts.IReadWriteWallet }) {
                 message,
                 signatory: await wallet.signatory().mnemonic(mnemonic),
             });
+        },
+        /**
+         * Returns the address for the wallet.
+         *
+         * @returns {string}
+         */
+        address(): string {
+            return wallet.address();
+        },
+        /**
+         * Returns the network of a wallet.
+         *
+         * @returns {Networks.Network}
+         */
+        network(): Networks.Network {
+            return wallet.coin().network();
         },
     };
 }

--- a/src/shared/components/header/AddressesDropdown.tsx
+++ b/src/shared/components/header/AddressesDropdown.tsx
@@ -12,7 +12,6 @@ import {
 } from '@/components/wallet/address/Address.blocks';
 import { Icon, RadioButton } from '@/shared/components';
 
-import { ExtensionEvents } from '@/lib/events';
 import { getNetworkCurrency } from '@/lib/utils/getActiveCoin';
 import { primaryWalletIdChanged } from '@/lib/store/wallet';
 import { useAppDispatch } from '@/lib/store';

--- a/src/shared/components/header/AddressesDropdown.tsx
+++ b/src/shared/components/header/AddressesDropdown.tsx
@@ -71,14 +71,6 @@ export const AddressesDropdown = ({
         await persist();
         await initProfile();
 
-        void ExtensionEvents({ profile }).changeAddress({
-            wallet: {
-                network: newPrimaryAddress.network().name(),
-                address: newPrimaryAddress.address(),
-                coin: newPrimaryAddress.network().coin(),
-            },
-        });
-
         const switchNetworkToast: string = 'Primary address changed';
         toast('success', switchNetworkToast);
     };


### PR DESCRIPTION
Closes https://app.clickup.com/t/86dtkphj3

Currently when the user changes the primary address, the extension emits the change event from the client side, which is error prone for cases where the user quickly closes the extension window before the change action finishes. 


This PR emits the change address event from the background in order to properly emit the event to active sessions even if the extension is closed.

