### PR TITLE
fix: ignore duplication check when saving same address

### DIFF
--- a/src/pages/EditContact.tsx
+++ b/src/pages/EditContact.tsx
@@ -46,7 +46,7 @@ const EditContact = () => {
                 'unique-address',
                 t('ERROR.IS_DUPLICATED', { name: 'contact address' }),
                 (address) => {
-                    if(contact?.address === address) return true;
+                    if (contact?.address === address) return true;
                     return !addressBook?.find((contact) => contact.address === address);
                 },
             ),

--- a/src/pages/EditContact.tsx
+++ b/src/pages/EditContact.tsx
@@ -46,6 +46,7 @@ const EditContact = () => {
                 'unique-address',
                 t('ERROR.IS_DUPLICATED', { name: 'contact address' }),
                 (address) => {
+                    if(contact?.address === address) return true;
                     return !addressBook?.find((contact) => contact.address === address);
                 },
             ),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[address book] edit contact does not allow you to save]()

## Summary

- Edit form ignores the duplication check fi we're saving the same initial address.

<!-- What changes are being made? -->

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/0dbb1152-4f83-4f92-b6f6-880bf5664b72


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
