### PR TITLE
fix: adjust colors for splash screen

### DIFF
--- a/src/pages/SplashScreen.tsx
+++ b/src/pages/SplashScreen.tsx
@@ -19,14 +19,14 @@ const SplashScreen = () => {
     if (animationFinished) return <Navigate to={'/onboarding'} />;
 
     return (
-        <div className='fixed left-0 top-0 flex h-[600px] w-full animate-slideUp flex-col items-center justify-center bg-theme-primary-700'>
+        <div className='fixed left-0 top-0 flex h-[600px] w-full animate-slideUp flex-col items-center justify-center bg-theme-primary-700 green:bg-[#058751]'>
             <div className='flex animate-fadeInTransformAndScale flex-col items-center justify-center gap-4'>
                 <Icon
                     className='splash-screen-icon h-[38px] w-[38px] text-white'
                     icon='logo-icon'
                 />
                 <Icon
-                    className='splash-screen-icon h-4 w-[170px] dark:text-white'
+                    className='splash-screen-icon h-4 w-[170px] text-theme-primary-200 green:text-[#00FF97]'
                     icon='logo-text'
                 />
             </div>

--- a/src/pages/SplashScreen.tsx
+++ b/src/pages/SplashScreen.tsx
@@ -19,14 +19,14 @@ const SplashScreen = () => {
     if (animationFinished) return <Navigate to={'/onboarding'} />;
 
     return (
-        <div className='fixed left-0 top-0 flex h-[600px] w-full animate-slideUp flex-col items-center justify-center bg-theme-primary-700 green:bg-[#058751]'>
+        <div className='fixed left-0 top-0 flex h-[600px] w-full animate-slideUp flex-col items-center justify-center bg-theme-primary-700'>
             <div className='flex animate-fadeInTransformAndScale flex-col items-center justify-center gap-4'>
                 <Icon
                     className='splash-screen-icon h-[38px] w-[38px] text-white'
                     icon='logo-icon'
                 />
                 <Icon
-                    className='splash-screen-icon h-4 w-[170px] text-theme-primary-200 green:text-[#00FF97]'
+                    className='splash-screen-icon h-4 w-[170px] text-theme-primary-200 green:text-theme-primary-300'
                     icon='logo-text'
                 />
             </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] adjust splash screen colors](https://app.clickup.com/t/86dtpt7d3)

## Summary

- Colors for splash screen in both the logo and the background have been updated.

<img width="363" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/ad872ae7-b110-47df-9362-ab0428e09367">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
