### PR TITLE
refactor: copy transaction id button

### DIFF
--- a/src/components/approve/ActionBody.blocks.tsx
+++ b/src/components/approve/ActionBody.blocks.tsx
@@ -2,11 +2,11 @@ import { useTranslation } from 'react-i18next';
 import { useRef } from 'react';
 import cn from 'classnames';
 import { Address } from '../wallet/address/Address.blocks';
+import { CopyTransactionId } from '../transaction/details/CopyTransactionId';
 import { ActionDetailsFiatValue, ActionDetailsRow } from './ActionDetails';
 import { ActionDetailsValue } from './ActionDetailsValue';
-import { Icon, Tooltip } from '@/shared/components';
+import { Tooltip } from '@/shared/components';
 import trimAddress from '@/lib/utils/trimAddress';
-import useClipboard from '@/lib/hooks/useClipboard';
 import Amount from '@/components/wallet/Amount';
 import useAddressBook from '@/lib/hooks/useAddressBook';
 
@@ -96,22 +96,13 @@ export const ActionAmountRow = ({
 
 export const ActionTransactionIdRow = ({ transactionId }: { transactionId: string }) => {
     const { t } = useTranslation();
-    const { copy } = useClipboard();
 
     return (
         <ActionDetailsRow label={t('COMMON.TRANSACTION_ID')}>
             <div className='flex items-center gap-1'>
                 <ActionDetailsValue>{trimAddress(transactionId, 'short')}</ActionDetailsValue>
-                <button
-                    type='button'
-                    className='block'
-                    onClick={() => copy(transactionId, t('COMMON.TRANSACTION_ID'))}
-                >
-                    <Icon
-                        icon='copy'
-                        className='h-5 w-5 text-theme-primary-700 dark:text-theme-primary-650'
-                    />
-                </button>
+
+                <CopyTransactionId transactionId={transactionId} />
             </div>
         </ActionDetailsRow>
     );

--- a/src/components/transaction/details/CopyTransactionId.tsx
+++ b/src/components/transaction/details/CopyTransactionId.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from 'react-i18next';
+import useClipboard from '@/lib/hooks/useClipboard';
+import { Icon, Tooltip } from '@/shared/components';
+
+
+export const CopyTransactionId = ({
+    transactionId
+}: {
+    transactionId: string;
+}) => {
+    const { t } = useTranslation();
+    const { copy } = useClipboard();
+
+    return (
+        <Tooltip content={t('COMMON.COPY_with_name', {name: 'TxID'})}>
+            <button
+                type='button'
+                className='block p-2 rounded-full dark:hover:bg-theme-secondary-700 bg-transparent transition-smoothEase dark:text-white text-light-black hover:bg-theme-secondary-100'
+                onClick={() => copy(transactionId, t('COMMON.TRANSACTION_ID'))}
+            >
+                <Icon
+                    icon='copy'
+                    className='h-4 w-4'
+                />
+            </button>
+        </Tooltip>
+    );
+};

--- a/src/components/transaction/details/CopyTransactionId.tsx
+++ b/src/components/transaction/details/CopyTransactionId.tsx
@@ -2,26 +2,18 @@ import { useTranslation } from 'react-i18next';
 import useClipboard from '@/lib/hooks/useClipboard';
 import { Icon, Tooltip } from '@/shared/components';
 
-
-export const CopyTransactionId = ({
-    transactionId
-}: {
-    transactionId: string;
-}) => {
+export const CopyTransactionId = ({ transactionId }: { transactionId: string }) => {
     const { t } = useTranslation();
     const { copy } = useClipboard();
 
     return (
-        <Tooltip content={t('COMMON.COPY_with_name', {name: 'TxID'})}>
+        <Tooltip content={t('COMMON.COPY_with_name', { name: 'TxID' })}>
             <button
                 type='button'
-                className='block p-2 rounded-full dark:hover:bg-theme-secondary-700 bg-transparent transition-smoothEase dark:text-white text-light-black hover:bg-theme-secondary-100'
+                className='transition-smoothEase block rounded-full bg-transparent p-2 text-light-black hover:bg-theme-secondary-100 dark:text-white dark:hover:bg-theme-secondary-700'
                 onClick={() => copy(transactionId, t('COMMON.TRANSACTION_ID'))}
             >
-                <Icon
-                    icon='copy'
-                    className='h-4 w-4'
-                />
+                <Icon icon='copy' className='h-4 w-4' />
             </button>
         </Tooltip>
     );

--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -6,14 +6,14 @@ import {
     TransactionUniqueRecipients,
 } from '../Transaction.blocks';
 import { TrasactionItem } from './TrasactionItem';
-import { Button, ExternalLink, Icon, Tooltip } from '@/shared/components';
+import { CopyTransactionId } from './CopyTransactionId';
+import { Button, ExternalLink, Tooltip } from '@/shared/components';
 import { getType, renderAmount, TransactionType } from '@/components/home/LatestTransactions.utils';
 
 import Amount from '@/components/wallet/Amount';
 import { formatUnixTimestamp } from '@/lib/utils/formatUnixTimestsamp';
 import { getTransactionDetailLink } from '@/lib/utils/networkUtils';
 import trimAddress from '@/lib/utils/trimAddress';
-import useClipboard from '@/lib/hooks/useClipboard';
 import { useDelegateInfo } from '@/lib/hooks/useDelegateInfo';
 import { useExchangeRate } from '@/lib/hooks/useExchangeRate';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
@@ -25,7 +25,6 @@ export const TransactionBody = ({
 }) => {
     const primaryWallet = usePrimaryWallet();
     const { t } = useTranslation();
-    const { copy } = useClipboard();
     const { voteDelegate, unvoteDelegate } = useDelegateInfo(transaction, primaryWallet);
     const { convert } = useExchangeRate({
         exchangeTicker: primaryWallet?.exchangeCurrency(),
@@ -150,16 +149,7 @@ export const TransactionBody = ({
                         <Tooltip content={transaction.id()} className='break-words'>
                             <span>{trimAddress(transaction.id(), 'longest')}</span>
                         </Tooltip>
-                        <button
-                            type='button'
-                            className='block'
-                            onClick={() => copy(transaction.id(), t('COMMON.TRANSACTION_ID'))}
-                        >
-                            <Icon
-                                icon='copy'
-                                className='h-5 w-5 text-theme-primary-700 dark:text-theme-primary-650'
-                            />
-                        </button>
+                        <CopyTransactionId transactionId={transaction.id()} />
                     </div>
                 </TrasactionItem>
 

--- a/src/components/transaction/details/TransactionBody.tsx
+++ b/src/components/transaction/details/TransactionBody.tsx
@@ -7,7 +7,7 @@ import {
 } from '../Transaction.blocks';
 import { TrasactionItem } from './TrasactionItem';
 import { CopyTransactionId } from './CopyTransactionId';
-import { Button, ExternalLink, Tooltip } from '@/shared/components';
+import { Tooltip } from '@/shared/components';
 import { getType, renderAmount, TransactionType } from '@/components/home/LatestTransactions.utils';
 
 import Amount from '@/components/wallet/Amount';


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[tx details] adjust copy icon styling](https://app.clickup.com/t/86dtpuw6x)

## Summary

- New `CopyTransactionId` component.
- The button to copy the transaction id has been refactored, implementing new styles and a new copy on tooltip.

<img width="367" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/d61c780f-266c-4bb1-ace0-c9b3b3ba1628">
<img width="365" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/ad6b6862-8128-4ee3-a47e-e23a3ad9a5fc">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
