### PR TITLE
fix: adjust button styles

### DIFF
--- a/src/components/settings/others/MultipleWalletLogout.tsx
+++ b/src/components/settings/others/MultipleWalletLogout.tsx
@@ -56,7 +56,7 @@ const MultipleWalletLogout = () => {
                         }}
                         disabled={!selectedIdsToLogout.length}
                     >
-                        {t('ACTION.REMOVE')}{' '}
+                        {t('ACTION.REMOVE', { name: 'Address' })}{' '}
                         {selectedIdsToLogout.length > 0 && `(${selectedIdsToLogout.length})`}
                     </Button>
                     <Button variant='primaryLinkDestructive' onClick={handleSelectAllWallets}>

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -74,9 +74,16 @@
         @apply text-theme-secondary-500 dark:text-theme-secondary-400;
     }
 
+    /** Button Secondary Link **/
+    .button-secondaryLink {
+        @apply bg-transparent p-0 text-light-black underline decoration-transparent hover:text-theme-primary-700 hover:decoration-theme-primary-700 hover:green:text-theme-primary-600 hover:green:decoration-theme-primary-600
+        dark:text-white 
+        dark:hover:text-theme-primary-700;
+    }
+
     /** Button Primary Link Destructive **/
     .button-primaryLinkDestructive {
-        @apply bg-transparent p-0 font-medium text-theme-error-600 dark:text-theme-error-500;
+        @apply bg-transparent p-0 font-medium text-theme-error-600 underline decoration-transparent hover:decoration-theme-error-600 dark:text-theme-error-500 hover:dark:decoration-theme-error-500;
     }
     .button-primaryLinkDestructive:focus-visible {
         @apply outline-2 outline-theme-error-700;

--- a/src/i18n/ns/action.ts
+++ b/src/i18n/ns/action.ts
@@ -12,7 +12,7 @@ export default {
     DISCONNECT: 'Disconnect',
     IMPORT: 'Import',
     REFUSE: 'Refuse',
-    REMOVE: 'Remove',
+    REMOVE: 'Remove {{name}}',
     SAVE: 'Save',
     SHOW_PASSPHRASE: 'Show Passphrase',
 };

--- a/src/pages/Logout.tsx
+++ b/src/pages/Logout.tsx
@@ -145,9 +145,10 @@ const Logout = () => {
                     </Button>
                     <Button
                         onClick={() => navigate(-1)}
-                        className='mb-0 flex w-full bg-transparent py-0 text-light-black dark:text-white'
+                        className='mb-0 flex w-full bg-transparent py-0'
+                        variant='secondaryLink'
                     >
-                        <span className='typeset-headline font-medium text-light-black dark:text-white'>
+                        <span className='typeset-headline font-medium'>
                             {t('ACTION.CANCEL_AND_GO_BACK')}
                         </span>
                     </Button>

--- a/src/shared/components/button/Button.tsx
+++ b/src/shared/components/button/Button.tsx
@@ -13,7 +13,8 @@ type ButtonVariant =
     | 'primaryLinkDestructive'
     | 'linkDestructive'
     | 'destructivePrimary'
-    | 'destructiveSecondary';
+    | 'destructiveSecondary'
+    | 'secondaryLink';
 
 type ButtonProps = React.ComponentPropsWithRef<'button'> & {
     iconLeading?: IconDefinition;
@@ -35,6 +36,7 @@ const buttonClass: Record<ButtonVariant, string> = {
     linkDestructive: 'button-linkDestructive',
     destructivePrimary: 'button-destructivePrimary',
     destructiveSecondary: 'button-destructiveSecondary',
+    secondaryLink: 'button-secondaryLink',
 };
 
 const getButtonClass = (variant?: ButtonVariant) => (variant ? buttonClass[variant] : '');


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] adjust some button styles](https://app.clickup.com/t/86dtpt7da)

## Summary

- Depends on #354 
- Button styles for `primary link button` have been updated.
- Text content for remove button has also been updated.
- New `secondaryLink` button variant.

<img width="364" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/e88b80ed-6764-4c9c-ac21-63fcf557d713">

<img width="361" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/11b4139d-474c-4ff4-935f-acf55c6b23fd">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
