### PR TITLE
refactor: make incoming amounts green

### DIFF
--- a/src/components/transaction/details/AmountBadge.tsx
+++ b/src/components/transaction/details/AmountBadge.tsx
@@ -25,7 +25,7 @@ export const AmountBadge = ({
             className={cn('flex items-center justify-center rounded-md border p-1.5', {
                 'border-theme-secondary-500 text-light-black dark:border-theme-secondary-300 dark:text-white':
                     type === 'default',
-                'border-theme-primary-700 text-theme-primary-700 dark:border-theme-primary-600 dark:text-theme-primary-600':
+                'border-theme-green-700 text-theme-green-700 dark:border-theme-green-600 dark:text-theme-green-600':
                     type === 'positive',
                 'border-theme-error-600 text-theme-error-600 dark:border-theme-error-500 dark:text-theme-error-500':
                     type === 'negative',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[tx details] make incoming amounts green](https://app.clickup.com/t/86dtq7nm3)

## Summary

<!-- What changes are being made? -->

- Amount badge with positive amounts will always be green, ignoring the chosen color palette.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

<img width="368" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/1faf774c-4257-4168-893c-3be8a266656b">


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
