### PR TITLE
refactor: adjust styles for receive page buttons

### DIFF
--- a/src/components/receive/QRActionButtons.tsx
+++ b/src/components/receive/QRActionButtons.tsx
@@ -15,7 +15,7 @@ export const QRActionButtons = ({
     return (
         <button
             className={cn(
-                'transition-smoothEase flex flex-row items-center gap-3 px-5 py-1 text-base font-medium text-light-black hover:bg-theme-secondary-50 dark:text-theme-secondary-200 dark:hover:bg-theme-secondary-700 rounded-2xl',
+                'transition-smoothEase flex flex-row items-center gap-3 rounded-2xl px-5 py-1 text-base font-medium text-light-black hover:bg-theme-secondary-50 dark:text-theme-secondary-200 dark:hover:bg-theme-secondary-700',
                 className,
             )}
             onClick={onClick}

--- a/src/components/receive/QRActionButtons.tsx
+++ b/src/components/receive/QRActionButtons.tsx
@@ -15,7 +15,7 @@ export const QRActionButtons = ({
     return (
         <button
             className={cn(
-                'transition-smoothEase flex flex-row items-center gap-3 px-5 py-1 text-base font-medium text-light-black hover:text-theme-secondary-600 dark:text-theme-secondary-200 dark:hover:text-white',
+                'transition-smoothEase flex flex-row items-center gap-3 px-5 py-1 text-base font-medium text-light-black hover:bg-theme-secondary-50 dark:text-theme-secondary-200 dark:hover:bg-theme-secondary-700 rounded-2xl',
                 className,
             )}
             onClick={onClick}

--- a/src/components/receive/Recipient.tsx
+++ b/src/components/receive/Recipient.tsx
@@ -13,9 +13,9 @@ export const Recipient = () => {
             <span className='text-sm font-medium text-theme-secondary-500 dark:text-theme-secondary-200'>
                 {t('COMMON.RECIPIENT')}
             </span>
-            <div className='flex w-full items-center justify-between rounded-lg border border-theme-secondary-200 bg-white pl-3 pr-1.5 py-2.5 dark:border-theme-secondary-600 dark:bg-theme-secondary-800 dark:text-theme-secondary-400 dark:shadow-secondary-dark'>
+            <div className='flex w-full items-center justify-between rounded-lg border border-theme-secondary-200 bg-white py-2.5 pl-3 pr-1.5 dark:border-theme-secondary-600 dark:bg-theme-secondary-800 dark:text-theme-secondary-400 dark:shadow-secondary-dark'>
                 <TransactionAddress address={address} displayParenthesis />
-                <CopyAddress disableTooltip/>
+                <CopyAddress disableTooltip />
             </div>
         </div>
     );

--- a/src/components/receive/Recipient.tsx
+++ b/src/components/receive/Recipient.tsx
@@ -13,7 +13,7 @@ export const Recipient = () => {
             <span className='text-sm font-medium text-theme-secondary-500 dark:text-theme-secondary-200'>
                 {t('COMMON.RECIPIENT')}
             </span>
-            <div className='flex w-full items-center justify-between rounded-lg border border-theme-secondary-200 bg-white px-3 py-4 dark:border-theme-secondary-600 dark:bg-theme-secondary-800 dark:text-theme-secondary-400 dark:shadow-secondary-dark'>
+            <div className='flex w-full items-center justify-between rounded-lg border border-theme-secondary-200 bg-white pl-3 pr-1.5 py-2.5 dark:border-theme-secondary-600 dark:bg-theme-secondary-800 dark:text-theme-secondary-400 dark:shadow-secondary-dark'>
                 <TransactionAddress address={address} displayParenthesis />
                 <CopyAddress disableTooltip/>
             </div>

--- a/src/components/receive/Recipient.tsx
+++ b/src/components/receive/Recipient.tsx
@@ -1,15 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { TransactionAddress } from '../transaction/Transaction.blocks';
+import { CopyAddress } from '../wallet/CopyAddress';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
-import useClipboard from '@/lib/hooks/useClipboard';
-import trimAddress from '@/lib/utils/trimAddress';
-import { Icon } from '@/shared/components';
 
 export const Recipient = () => {
     const primaryWallet = usePrimaryWallet();
     const address = primaryWallet?.address() ?? '';
     const { t } = useTranslation();
-    const { copy } = useClipboard();
 
     return (
         <div className='flex flex-col gap-1.5'>
@@ -18,16 +15,7 @@ export const Recipient = () => {
             </span>
             <div className='flex w-full items-center justify-between rounded-lg border border-theme-secondary-200 bg-white px-3 py-4 dark:border-theme-secondary-600 dark:bg-theme-secondary-800 dark:text-theme-secondary-400 dark:shadow-secondary-dark'>
                 <TransactionAddress address={address} displayParenthesis />
-                <button
-                    type='button'
-                    className='block'
-                    onClick={() => copy(address, trimAddress(address, 'short'))}
-                >
-                    <Icon
-                        icon='copy'
-                        className='h-5 w-5 text-theme-primary-700 dark:text-theme-primary-600'
-                    />
-                </button>
+                <CopyAddress disableTooltip/>
             </div>
         </div>
     );

--- a/src/components/receive/Recipient.tsx
+++ b/src/components/receive/Recipient.tsx
@@ -15,7 +15,7 @@ export const Recipient = () => {
             </span>
             <div className='flex w-full items-center justify-between rounded-lg border border-theme-secondary-200 bg-white py-2.5 pl-3 pr-1.5 dark:border-theme-secondary-600 dark:bg-theme-secondary-800 dark:text-theme-secondary-400 dark:shadow-secondary-dark'>
                 <TransactionAddress address={address} displayParenthesis />
-                <CopyAddress disableTooltip />
+                <CopyAddress />
             </div>
         </div>
     );

--- a/src/components/wallet/CopyAddress.tsx
+++ b/src/components/wallet/CopyAddress.tsx
@@ -19,10 +19,7 @@ export const CopyAddress = () => {
     const trimmedAddress = trimAddress(primaryWallet.address(), 10);
 
     return (
-        <Tooltip
-            content={t('COMMON.COPY_with_name', { name: 'Address' })}
-            placement='bottom-end'
-        >
+        <Tooltip content={t('COMMON.COPY_with_name', { name: 'Address' })} placement='bottom-end'>
             <HeaderButton
                 className='rounded-full'
                 onClick={() => {

--- a/src/components/wallet/CopyAddress.tsx
+++ b/src/components/wallet/CopyAddress.tsx
@@ -6,11 +6,7 @@ import trimAddress from '@/lib/utils/trimAddress';
 import { ToastPosition } from '@/components/toast/ToastContainer';
 import { HeaderButton } from '@/shared/components/header/HeaderButton';
 
-export const CopyAddress = ({
-    disableTooltip = false,
-}: {
-    disableTooltip?: boolean;
-}) => {
+export const CopyAddress = ({ disableTooltip = false }: { disableTooltip?: boolean }) => {
     const primaryWallet = usePrimaryWallet();
     const { t } = useTranslation();
 
@@ -23,7 +19,11 @@ export const CopyAddress = ({
     const trimmedAddress = trimAddress(primaryWallet.address(), 10);
 
     return (
-        <Tooltip content={t('COMMON.COPY_with_name', { name: 'Address'})} placement='bottom-end' disabled={disableTooltip}>
+        <Tooltip
+            content={t('COMMON.COPY_with_name', { name: 'Address' })}
+            placement='bottom-end'
+            disabled={disableTooltip}
+        >
             <HeaderButton
                 className='rounded-full'
                 onClick={() => {

--- a/src/components/wallet/CopyAddress.tsx
+++ b/src/components/wallet/CopyAddress.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Icon, Tooltip } from '@/shared/components';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
 import useClipboard from '@/lib/hooks/useClipboard';
@@ -5,8 +6,13 @@ import trimAddress from '@/lib/utils/trimAddress';
 import { ToastPosition } from '@/components/toast/ToastContainer';
 import { HeaderButton } from '@/shared/components/header/HeaderButton';
 
-export const CopyAddress = () => {
+export const CopyAddress = ({
+    disableTooltip = false,
+}: {
+    disableTooltip?: boolean;
+}) => {
     const primaryWallet = usePrimaryWallet();
+    const { t } = useTranslation();
 
     const { copy } = useClipboard();
 
@@ -17,7 +23,7 @@ export const CopyAddress = () => {
     const trimmedAddress = trimAddress(primaryWallet.address(), 10);
 
     return (
-        <Tooltip content='Copy address' placement='bottom-end'>
+        <Tooltip content={t('COMMON.COPY_with_name', { name: 'Address'})} placement='bottom-end' disabled={disableTooltip}>
             <HeaderButton
                 className='rounded-full'
                 onClick={() => {

--- a/src/components/wallet/CopyAddress.tsx
+++ b/src/components/wallet/CopyAddress.tsx
@@ -6,7 +6,7 @@ import trimAddress from '@/lib/utils/trimAddress';
 import { ToastPosition } from '@/components/toast/ToastContainer';
 import { HeaderButton } from '@/shared/components/header/HeaderButton';
 
-export const CopyAddress = ({ disableTooltip = false }: { disableTooltip?: boolean }) => {
+export const CopyAddress = () => {
     const primaryWallet = usePrimaryWallet();
     const { t } = useTranslation();
 
@@ -22,7 +22,6 @@ export const CopyAddress = ({ disableTooltip = false }: { disableTooltip?: boole
         <Tooltip
             content={t('COMMON.COPY_with_name', { name: 'Address' })}
             placement='bottom-end'
-            disabled={disableTooltip}
         >
             <HeaderButton
                 className='rounded-full'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[receive] Change 'Copy' color and hover and QR Save/Copy hovers](https://app.clickup.com/t/86dtq7q5f)

## Summary

- Hover styles for buttons in `Receive` page have been updated.
- `CopyAddress` button has been refactored.
- Paddings for the recipient input have also been adjusted to match the design.

<img width="375" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/61e609bc-87bf-4fac-9da4-0bc457456801">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
