### PR TITLE
fix: button placement consistency on onboarding pages

### DIFF
--- a/src/components/settings/SetupPassword.tsx
+++ b/src/components/settings/SetupPassword.tsx
@@ -143,6 +143,7 @@ const SetupPassword = ({ formik }: Props) => {
                             </label>
                         </div>
                     </div>
+                </div>
 
                     <Button
                         className='mt-6'
@@ -152,7 +153,6 @@ const SetupPassword = ({ formik }: Props) => {
                     >
                         Confirm
                     </Button>
-                </div>
             </div>
         </div>
     );

--- a/src/components/settings/SetupPassword.tsx
+++ b/src/components/settings/SetupPassword.tsx
@@ -145,14 +145,14 @@ const SetupPassword = ({ formik }: Props) => {
                     </div>
                 </div>
 
-                    <Button
-                        className='mt-6'
-                        variant='primary'
-                        disabled={!values.termsAndConditionsConfirmed || !isValid}
-                        onClick={submitForm}
-                    >
-                        Confirm
-                    </Button>
+                <Button
+                    className='mt-6'
+                    variant='primary'
+                    disabled={!values.termsAndConditionsConfirmed || !isValid}
+                    onClick={submitForm}
+                >
+                    Confirm
+                </Button>
             </div>
         </div>
     );


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

- Button placement for onboarding pages is now consistent.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Screenshots

<img width="364" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/12596538-6ff0-4a41-ab0c-b6ec0fc9eaec">


<img width="359" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/259686d8-ceed-4633-8006-25f6210d738b">

<img width="371" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/47ceddee-f472-4fde-8583-f29971475326">


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
