### PR TITLE
refactor: make address tooltips consistent

### DIFF
--- a/src/components/wallet/CopyAddress.tsx
+++ b/src/components/wallet/CopyAddress.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Icon, Tooltip } from '@/shared/components';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
 import useClipboard from '@/lib/hooks/useClipboard';
@@ -7,6 +8,7 @@ import { HeaderButton } from '@/shared/components/header/HeaderButton';
 
 export const CopyAddress = () => {
     const primaryWallet = usePrimaryWallet();
+    const { t } = useTranslation();
 
     const { copy } = useClipboard();
 
@@ -17,7 +19,7 @@ export const CopyAddress = () => {
     const trimmedAddress = trimAddress(primaryWallet.address(), 10);
 
     return (
-        <Tooltip content='Copy address' placement='bottom-end'>
+        <Tooltip content={t('COMMON.COPY_with_name', { name: 'Address' })} placement='bottom-end'>
             <HeaderButton
                 className='rounded-full'
                 onClick={() => {

--- a/src/components/wallet/address/Address.blocks.tsx
+++ b/src/components/wallet/address/Address.blocks.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { TippyProps } from '@tippyjs/react';
 import cn from 'classnames';
 import { twMerge } from 'tailwind-merge';
+import { useTranslation } from 'react-i18next';
 import Amount from '@/components/wallet/Amount';
 import { Icon, Tooltip } from '@/shared/components';
 import trimAddress from '@/lib/utils/trimAddress';
@@ -91,6 +92,7 @@ export const Address = ({
 
 export const AddressWithCopy = ({ address, length = 10 }: { address: string; length?: number }) => {
     const { copy } = useClipboard();
+    const { t } = useTranslation();
     const trimmedAddress = trimAddress(address, length);
 
     return (
@@ -100,7 +102,7 @@ export const AddressWithCopy = ({ address, length = 10 }: { address: string; len
                 copy(address, trimmedAddress, ToastPosition.LOWER);
             }}
         >
-            <Tooltip content='Copy address' placement='top'>
+            <Tooltip content={t('COMMON.COPY_with_name', { name: 'Address' })} placement='top'>
                 <div className='flex items-center gap-1.5'>
                     <p className='typeset-body text-theme-secondary-500 dark:text-theme-secondary-300'>
                         {trimmedAddress}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] consistent copy tooltips](https://app.clickup.com/t/86dtq98h9)

## Summary

- We now rely on `COPY_WITH_NAME` translation from i18n and capitalize the words in address tooltips to make them consistent.

<img width="365" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/93fa7031-c10d-4fb9-92f8-de65c09dc68a">

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
