### PR TITLE
refactor: implement i18n to address settings menu

### DIFF
--- a/src/components/wallet/AddressSettings.tsx
+++ b/src/components/wallet/AddressSettings.tsx
@@ -1,5 +1,6 @@
 import { Contracts } from '@ardenthq/sdk-profiles';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import Amount from './Amount';
 import SubPageLayout from '@/components/settings/SubPageLayout';
 import { Tooltip } from '@/shared/components';
@@ -15,6 +16,7 @@ import { handleSubmitKeyAction } from '@/lib/utils/handleKeyAction';
 
 export const AddressSettings = () => {
     const { state } = useLocation();
+    const { t } = useTranslation();
 
     const { address } = state;
 
@@ -23,13 +25,13 @@ export const AddressSettings = () => {
     const navigate = useNavigate();
 
     return (
-        <SubPageLayout title='Address Settings'>
+        <SubPageLayout title={t('PAGES.ADDRESS_SETTINGS.TITLE')}>
             <AddressRow address={address} />
             <SafeOutlineOverflowContainer>
                 <div className='my-2 flex flex-col overflow-hidden rounded-2xl bg-white py-2 dark:bg-subtle-black'>
                     <SettingsOption
                         iconLeading='pencil'
-                        title='Edit Name'
+                        title={t('PAGES.ADDRESS_SETTINGS.OPTIONS.EDIT_NAME')}
                         onClick={() => navigate(`/edit-address-name/${address.id()}`)}
                         iconTrailing='arrow-right'
                         onKeyDown={(e) =>
@@ -41,7 +43,7 @@ export const AddressSettings = () => {
 
                     <SettingsOption
                         iconLeading='copy'
-                        title='Copy Address'
+                        title={t('PAGES.ADDRESS_SETTINGS.OPTIONS.COPY_ADDRESS')}
                         onClick={() => {
                             copy(
                                 address.address(),
@@ -63,7 +65,7 @@ export const AddressSettings = () => {
                     <Tooltip
                         content={
                             <p>
-                                Ledger devices do not allow <br /> access to the passphrase.
+                                {t('PAGES.ADDRESS_SETTINGS.TOOLTIP.LEDGER_DEVICES_DO_NOT_ALLOW')}<br />{t('PAGES.ADDRESS_SETTINGS.TOOLTIP.ACCESS_TO', { name: 'passphrase'})}
                             </p>
                         }
                         placement='bottom'
@@ -72,7 +74,7 @@ export const AddressSettings = () => {
                         <SettingsOption
                             disabled={address.isLedger()}
                             iconLeading='show-passphrase'
-                            title='Show Passphrase'
+                            title={t('PAGES.ADDRESS_SETTINGS.OPTIONS.SHOW', { name: 'Passphrase'})}
                             onClick={() => {
                                 navigate(`/view-sensitive-info/${address.id()}/passphrase`);
                             }}
@@ -88,7 +90,7 @@ export const AddressSettings = () => {
                     <Tooltip
                         content={
                             <p>
-                                Ledger devices do not allow <br /> access to the private key.
+                            {t('PAGES.ADDRESS_SETTINGS.TOOLTIP.LEDGER_DEVICES_DO_NOT_ALLOW')}<br />{t('PAGES.ADDRESS_SETTINGS.TOOLTIP.ACCESS_TO', { name: 'private key'})}
                             </p>
                         }
                         placement='bottom'
@@ -97,7 +99,7 @@ export const AddressSettings = () => {
                         <SettingsOption
                             disabled={address.isLedger()}
                             iconLeading='key'
-                            title='Show Private Key'
+                            title={t('PAGES.ADDRESS_SETTINGS.OPTIONS.SHOW', { name: 'Private Key'})}
                             onClick={() => {
                                 navigate(`/view-sensitive-info/${address.id()}/privateKey`);
                             }}
@@ -112,7 +114,7 @@ export const AddressSettings = () => {
 
                     <SettingsOption
                         iconLeading='link-external'
-                        title='View on ARKScan'
+                        title={t('PAGES.ADDRESS_SETTINGS.OPTIONS.VIEW_ON_ARKSCAN')}
                         onClick={() => {
                             window.open(
                                 getExplorerDomain(address.network().isLive(), address.address()),
@@ -132,7 +134,7 @@ export const AddressSettings = () => {
 
                     <SettingsOption
                         iconLeading='trash'
-                        title='Remove Address'
+                        title={t('PAGES.ADDRESS_SETTINGS.OPTIONS.REMOVE_ADDRESS')}
                         onClick={() => {
                             navigate('/logout', { state: [address.id()] });
                         }}

--- a/src/components/wallet/AddressSettings.tsx
+++ b/src/components/wallet/AddressSettings.tsx
@@ -65,7 +65,11 @@ export const AddressSettings = () => {
                     <Tooltip
                         content={
                             <p>
-                                {t('PAGES.ADDRESS_SETTINGS.TOOLTIP.LEDGER_DEVICES_DO_NOT_ALLOW')}<br />{t('PAGES.ADDRESS_SETTINGS.TOOLTIP.ACCESS_TO', { name: 'passphrase'})}
+                                {t('PAGES.ADDRESS_SETTINGS.TOOLTIP.LEDGER_DEVICES_DO_NOT_ALLOW')}
+                                <br />
+                                {t('PAGES.ADDRESS_SETTINGS.TOOLTIP.ACCESS_TO', {
+                                    name: 'passphrase',
+                                })}
                             </p>
                         }
                         placement='bottom'
@@ -74,7 +78,7 @@ export const AddressSettings = () => {
                         <SettingsOption
                             disabled={address.isLedger()}
                             iconLeading='show-passphrase'
-                            title={t('PAGES.ADDRESS_SETTINGS.OPTIONS.SHOW', { name: 'Passphrase'})}
+                            title={t('PAGES.ADDRESS_SETTINGS.OPTIONS.SHOW', { name: 'Passphrase' })}
                             onClick={() => {
                                 navigate(`/view-sensitive-info/${address.id()}/passphrase`);
                             }}
@@ -90,7 +94,11 @@ export const AddressSettings = () => {
                     <Tooltip
                         content={
                             <p>
-                            {t('PAGES.ADDRESS_SETTINGS.TOOLTIP.LEDGER_DEVICES_DO_NOT_ALLOW')}<br />{t('PAGES.ADDRESS_SETTINGS.TOOLTIP.ACCESS_TO', { name: 'private key'})}
+                                {t('PAGES.ADDRESS_SETTINGS.TOOLTIP.LEDGER_DEVICES_DO_NOT_ALLOW')}
+                                <br />
+                                {t('PAGES.ADDRESS_SETTINGS.TOOLTIP.ACCESS_TO', {
+                                    name: 'private key',
+                                })}
                             </p>
                         }
                         placement='bottom'
@@ -99,7 +107,9 @@ export const AddressSettings = () => {
                         <SettingsOption
                             disabled={address.isLedger()}
                             iconLeading='key'
-                            title={t('PAGES.ADDRESS_SETTINGS.OPTIONS.SHOW', { name: 'Private Key'})}
+                            title={t('PAGES.ADDRESS_SETTINGS.OPTIONS.SHOW', {
+                                name: 'Private Key',
+                            })}
                             onClick={() => {
                                 navigate(`/view-sensitive-info/${address.id()}/privateKey`);
                             }}

--- a/src/i18n/ns/pages.ts
+++ b/src/i18n/ns/pages.ts
@@ -262,4 +262,18 @@ export default {
         ENTER_OR_CHOOSE_FROM_SAVED_ADDRESSES: 'Enter or choose from saved addresses',
         RECIPIENT_ADDRESS: 'Recipient Address',
     },
+    ADDRESS_SETTINGS: {
+        TITLE: 'Address Settings',
+        OPTIONS: {
+            EDIT_NAME: 'Edit Name',
+            COPY_ADDRESS: 'Copy Address',
+            SHOW: 'Show {{ name }}',
+            VIEW_ON_ARKSCAN: 'View on ARKscan',
+            REMOVE_ADDRESS: 'Remove Address',
+        },
+        TOOLTIP: {
+            LEDGER_DEVICES_DO_NOT_ALLOW: 'Ledger devices do not allow',
+            ACCESS_TO: 'access to the {{ name }}',
+        }
+    }
 };

--- a/src/i18n/ns/pages.ts
+++ b/src/i18n/ns/pages.ts
@@ -274,6 +274,6 @@ export default {
         TOOLTIP: {
             LEDGER_DEVICES_DO_NOT_ALLOW: 'Ledger devices do not allow',
             ACCESS_TO: 'access to the {{ name }}',
-        }
-    }
+        },
+    },
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[address settings] implement i18n for menu](https://app.clickup.com/t/86dtqpmzc)

## Summary

- `i18n` has been implemented for address settings menu page.

<img width="368" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/4478283f-8c26-4e3b-9003-6816070f6728">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
