### PR TITLE
fix: adjust padding between list and button

### DIFF
--- a/src/components/vote/DelegatesList.tsx
+++ b/src/components/vote/DelegatesList.tsx
@@ -41,7 +41,7 @@ export const DelegatesList = ({
     }
 
     return (
-        <div className='w-full flex-1 overflow-hidden rounded-xl bg-white py-2 dark:bg-subtle-black'>
+        <div className='w-full overflow-hidden rounded-xl bg-white py-2 dark:bg-subtle-black'>
             <table className='w-full'>
                 <tbody>
                     {delegates.map((delegate) => {

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -37,7 +37,7 @@ const Vote = () => {
         <SubPageLayout
             title={t('PAGES.VOTE.VOTE')}
             className='flex flex-1 flex-col'
-            bodyClassName='flex-1 flex flex-col'
+            bodyClassName='flex-1 flex flex-col pb-4'
             footer={<VoteButton onClick={() => {}} disabled={true} />}
         >
             <DelegatesSearchInput searchQuery={searchQuery} setSearchQuery={setSearchQuery} />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[vote] add padding between list and button](https://app.clickup.com/t/86dtr1btt)

## Summary

- Some padding has been added between the list and the button.

<img width="371" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/242fd53c-6e1d-46dd-b8ad-2cc9aca7235c">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
