### PR TITLE
fix: adjust vote fee styles

### DIFF
--- a/src/components/vote/VoteFee.tsx
+++ b/src/components/vote/VoteFee.tsx
@@ -59,7 +59,7 @@ export const VoteFee = ({
     }
 
     return (
-        <div className='flex h-[42px] items-center justify-between space-x-2 overflow-x-auto rounded-lg border border-theme-secondary-400 p-3 text-sm text-theme-secondary-500 dark:border-theme-secondary-500'>
+        <div className='flex h-[42px] items-center justify-between space-x-2 rounded-lg border border-theme-secondary-400 px-3 text-sm text-theme-secondary-500 dark:border-theme-secondary-500'>
             <span className='truncate text-sm font-medium dark:text-theme-secondary-200'>
                 {t('COMMON.TRANSACTION_FEE')}
             </span>

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -85,7 +85,7 @@ const Vote = () => {
         <SubPageLayout
             title={t('PAGES.VOTE.VOTE')}
             className='flex flex-1 flex-col'
-            bodyClassName='flex-1 flex flex-col'
+            bodyClassName='flex-1 flex flex-col pb-4'
             footer={
                 <Footer className='space-y-4'>
                     <VoteFee


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[vote] scrollbar appearing and padding missing on custom fee section](https://app.clickup.com/t/86dtt75zy)

## Summary

- Padding has been added to the delegate list on vote page.
- Issue of scrollbars appearing in the fee section has been fixed.

<img width="370" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/3af3cc25-abde-4841-9949-40a3e79a30d3">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
