### PR TITLE
fix: filter resigned delegates

### DIFF
--- a/src/lib/hooks/useDelegates.ts
+++ b/src/lib/hooks/useDelegates.ts
@@ -24,7 +24,10 @@ export const useDelegates = ({
 
             await env.delegates().sync(profile, wallet.coinId(), wallet.networkId());
 
-            const allDelegates = env.delegates().all(wallet.coinId(), wallet.networkId()).filter(delegate => !delegate.isResignedDelegate());
+            const allDelegates = env
+                .delegates()
+                .all(wallet.coinId(), wallet.networkId())
+                .filter((delegate) => !delegate.isResignedDelegate());
 
             setAllDelegates(allDelegates);
 

--- a/src/lib/hooks/useDelegates.ts
+++ b/src/lib/hooks/useDelegates.ts
@@ -24,7 +24,7 @@ export const useDelegates = ({
 
             await env.delegates().sync(profile, wallet.coinId(), wallet.networkId());
 
-            const allDelegates = env.delegates().all(wallet.coinId(), wallet.networkId());
+            const allDelegates = env.delegates().all(wallet.coinId(), wallet.networkId()).filter(delegate => !delegate.isResignedDelegate());
 
             setAllDelegates(allDelegates);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[vote] vote search doesn't exclude resigned delegates](https://app.clickup.com/t/86dttua21)

## Summary

- Resigned delegates are now being filtered.

<img width="369" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/74e74f49-c99e-4197-831b-63f1cf5c964f">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
