### PR TITLE
refactor: add missing text in delegate list

### DIFF
--- a/src/i18n/ns/pages.ts
+++ b/src/i18n/ns/pages.ts
@@ -42,6 +42,7 @@ export default {
             CURRENT: 'Current',
         },
         EDIT_FEE: 'Edit Fee',
+        USE_SEARCH_TO_FIND_DELEGATES: 'Use the search to find other delegates',
     },
     CREATE_WALLET: {
         SAVE_YOUR_SECRET_PASSPHRASE: 'Save Your Secret Passphrase',

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -231,15 +231,13 @@ const Vote = () => {
                 selectedDelegateAddress={formik.values.delegateAddress}
             />
 
-            {
-                !searchQuery && (
-                    <div className='mt-4'>
-                        <p className='text-sm text-theme-secondary-500 dark:text-theme-secondary-300 text-center w-full'>
-                            {t('PAGES.VOTE.USE_SEARCH_TO_FIND_DELEGATES')}
-                        </p>
-                    </div>
-                )
-            }
+            {!searchQuery && (
+                <div className='mt-4'>
+                    <p className='w-full text-center text-sm text-theme-secondary-500 dark:text-theme-secondary-300'>
+                        {t('PAGES.VOTE.USE_SEARCH_TO_FIND_DELEGATES')}
+                    </p>
+                </div>
+            )}
         </SubPageLayout>
     );
 };

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -230,6 +230,16 @@ const Vote = () => {
                 votes={currentVotes}
                 selectedDelegateAddress={formik.values.delegateAddress}
             />
+
+            {
+                !searchQuery && (
+                    <div className='mt-4'>
+                        <p className='text-sm text-theme-secondary-500 dark:text-theme-secondary-300 text-center w-full'>
+                            {t('PAGES.VOTE.USE_SEARCH_TO_FIND_DELEGATES')}
+                        </p>
+                    </div>
+                )
+            }
         </SubPageLayout>
     );
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[vote] missing "use search for other delegates" box](https://app.clickup.com/t/86dttumk4)

## Summary

 - Missing `'Use the search to find other delegates'` text has been added at the bottom of the delegate list when the search query is empty.

<img width="367" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/a10735fa-726d-45ec-b70f-6d7e9dddf801">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
