### PR TITLE
fix: error message width and word break

### DIFF
--- a/src/components/connect/ErrorModal.tsx
+++ b/src/components/connect/ErrorModal.tsx
@@ -20,7 +20,7 @@ const ErrorModal = ({ error, onClose }: Props) => {
                             {errorTitleParser(error)}
                         </Heading>
 
-                        <div className='text-center text-theme-secondary-500 dark:text-theme-secondary-300 break-words max-w-80'>
+                        <div className='max-w-80 break-words text-center text-theme-secondary-500 dark:text-theme-secondary-300'>
                             {error ? (
                                 <span
                                     dangerouslySetInnerHTML={{ __html: errorParser(error) }}

--- a/src/components/connect/ErrorModal.tsx
+++ b/src/components/connect/ErrorModal.tsx
@@ -20,7 +20,7 @@ const ErrorModal = ({ error, onClose }: Props) => {
                             {errorTitleParser(error)}
                         </Heading>
 
-                        <div className='text-center text-theme-secondary-500 dark:text-theme-secondary-300'>
+                        <div className='text-center text-theme-secondary-500 dark:text-theme-secondary-300 break-words max-w-80'>
                             {error ? (
                                 <span
                                     dangerouslySetInnerHTML={{ __html: errorParser(error) }}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] error doesn't fit on the page correctly](https://app.clickup.com/t/86dttuvr0)

## Summary

- Max width has been set for error message and long words will now break.

## Screenshots:

<img width="354" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/4bb2132d-0b98-473c-ad88-b18edd9a1bf0">

<img width="345" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/bd0a1cbe-fe29-418a-baed-b60be61ca5f9">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
