### PR TITLE
fix: infinite loading loop on voting errors

### DIFF
--- a/src/components/approve/ApproveVote.tsx
+++ b/src/components/approve/ApproveVote.tsx
@@ -173,6 +173,7 @@ const ApproveVote = ({ abortReference, approveWithLedger, wallet, closeLedgerScr
             closeLedgerScreen();
             reject(error.message);
             onError(error);
+            loadingModal.close();
         }
     };
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[vote] possible to get extension stuck processing a vote](https://app.clickup.com/t/86dtturnv)

## Summary

- When errors are displayed while voting, the infinite loading loop will not appear anymore.

<!-- What changes are being made? -->

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/25073bc2-e9d0-48c7-88aa-6c0e00fed677



<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
