### PR TITLE
fix: change delegate address cursor

### DIFF
--- a/src/components/wallet/address/Address.blocks.tsx
+++ b/src/components/wallet/address/Address.blocks.tsx
@@ -79,7 +79,7 @@ export const Address = ({
             <Tooltip content={address} placement={tooltipPlacement}>
                 <p
                     className={twMerge(
-                        'max-w-44 cursor-pointer text-sm font-normal leading-[17.5px] text-theme-secondary-500 underline-offset-2 hover:underline dark:text-theme-secondary-300',
+                        'max-w-44 cursor-default text-sm font-normal leading-[17.5px] text-theme-secondary-500 underline-offset-2 hover:underline dark:text-theme-secondary-300',
                         className,
                     )}
                 >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[vote] delegate address incorrect mouse cursor](https://app.clickup.com/t/86dttvbue)

## Summary

- The cursor for change delegate has been changed from `pointer` to `default`.

<img width="296" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/b3a3e4d8-28b9-443b-a31c-8a5791c92584">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
