### PR TITLE
fix: allow editing in transaction fee

### DIFF
--- a/src/components/vote/VoteFee.tsx
+++ b/src/components/vote/VoteFee.tsx
@@ -11,12 +11,14 @@ export const VoteFee = ({
     feeError,
     onSelectedFee,
     onBlur,
+    handleFeeInputChange,
 }: {
     delegateAddress?: string;
     fee: string;
     feeError?: string;
     onSelectedFee: (fee: string) => void;
     onBlur: FocusEventHandler<HTMLInputElement>;
+    handleFeeInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void
 }) => {
     const { t } = useTranslation();
     const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -47,6 +49,7 @@ export const VoteFee = ({
         return (
             <div ref={feeFormRef}>
                 <FeeSection
+                    onChange={handleFeeInputChange}
                     onBlur={onBlur}
                     variant={fee && feeError ? 'destructive' : 'primary'}
                     helperText={fee ? feeError : undefined}

--- a/src/components/vote/VoteFee.tsx
+++ b/src/components/vote/VoteFee.tsx
@@ -18,7 +18,7 @@ export const VoteFee = ({
     feeError?: string;
     onSelectedFee: (fee: string) => void;
     onBlur: FocusEventHandler<HTMLInputElement>;
-    handleFeeInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+    handleFeeInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }) => {
     const { t } = useTranslation();
     const [isEditing, setIsEditing] = useState<boolean>(false);

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -195,6 +195,11 @@ const Vote = () => {
         };
     }, [formik.values]);
 
+    const handleFeeInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        event.target.value = event.target.value.trim();
+        formik.handleChange(event);
+    };
+
     return (
         <SubPageLayout
             title={t('PAGES.VOTE.VOTE')}
@@ -208,6 +213,7 @@ const Vote = () => {
                         onSelectedFee={(fee) => formik.setFieldValue('fee', fee)}
                         onBlur={formik.handleBlur}
                         feeError={formik.errors.fee}
+                        handleFeeInputChange={handleFeeInputChange}
                     />
 
                     <VoteButton


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[vote] can't manually edit transaction fee](https://app.clickup.com/t/86dttv5mr)

## Summary

- Advanced fee input can now be edited as expected.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

<img width="359" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/b0de2ed5-b6ca-46ac-9045-e9d16f91257d">


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
