### PR TITLE
fix: allow use of fast preset fee

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,13 @@ const AMOUNT_REGEX = /^[0-9]+(\.[0-9]{1,8})?$/;
 // is 8 digits in total.
 const MAX_CURRENCY_DIGITS_ALLOWED = 9;
 
+// Max fee for transactions per supported type
+// set to static fee for the network
+const MAX_FEES = {
+    transfer: 0.1,
+    vote: 1,
+};
+
 const constants = {
     SUPPORT_EMAIL,
     ARKSCAN_MAINNET_TRANSACTIONS,
@@ -45,6 +52,7 @@ const constants = {
     TRANSACTION_CONFIRMATION_DELAY_MS,
     ADDRESS_LENGTH,
     AMOUNT_REGEX,
+    MAX_FEES,
 };
 
 export default constants;

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -92,7 +92,7 @@ const Send = () => {
                 return Number(value) > 0;
             })
             .test('max-value', t('ERROR.IS_TOO_HIGH', { name: 'Fee' }), (value) => {
-                return Number(value) < 1;
+                return Number(value) <= 1;
             })
             .trim(),
         receiverAddress: string()

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -1,20 +1,20 @@
-import { SendButton, SendForm } from '@/components/send';
 import { object, string } from 'yup';
 import { useEffect, useState } from 'react';
-
 import { BigNumber } from '@ardenthq/sdk-helpers';
+import { runtime } from 'webextension-polyfill';
+import { useFormik } from 'formik';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { validateAddress } from './CreateContact';
+import { SendButton, SendForm } from '@/components/send';
+
 import { ScreenName } from '@/lib/background/contracts';
 import SubPageLayout from '@/components/settings/SubPageLayout';
 import { ValidateAddressResponse } from '@/components/address-book/types';
 import { WalletNetwork } from '@/lib/store/wallet';
 import constants from '@/constants';
-import { runtime } from 'webextension-polyfill';
-import { useFormik } from 'formik';
-import { useNavigate } from 'react-router-dom';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
 import { useProfileContext } from '@/lib/context/Profile';
-import { useTranslation } from 'react-i18next';
-import { validateAddress } from './CreateContact';
 
 export type SendFormik = {
     amount?: string;

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -1,20 +1,20 @@
+import { SendButton, SendForm } from '@/components/send';
 import { object, string } from 'yup';
 import { useEffect, useState } from 'react';
 
 import { BigNumber } from '@ardenthq/sdk-helpers';
+import { ScreenName } from '@/lib/background/contracts';
+import SubPageLayout from '@/components/settings/SubPageLayout';
+import { ValidateAddressResponse } from '@/components/address-book/types';
+import { WalletNetwork } from '@/lib/store/wallet';
+import constants from '@/constants';
 import { runtime } from 'webextension-polyfill';
 import { useFormik } from 'formik';
 import { useNavigate } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
-import { validateAddress } from './CreateContact';
-import constants from '@/constants';
-import { ScreenName } from '@/lib/background/contracts';
-import SubPageLayout from '@/components/settings/SubPageLayout';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
 import { useProfileContext } from '@/lib/context/Profile';
-import { SendButton, SendForm } from '@/components/send';
-import { ValidateAddressResponse } from '@/components/address-book/types';
-import { WalletNetwork } from '@/lib/store/wallet';
+import { useTranslation } from 'react-i18next';
+import { validateAddress } from './CreateContact';
 
 export type SendFormik = {
     amount?: string;
@@ -92,7 +92,7 @@ const Send = () => {
                 return Number(value) > 0;
             })
             .test('max-value', t('ERROR.IS_TOO_HIGH', { name: 'Fee' }), (value) => {
-                return Number(value) <= 1;
+                return Number(value) <= constants.MAX_FEES.transfer;
             })
             .trim(),
         receiverAddress: string()

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -74,7 +74,7 @@ const Vote = () => {
                 return Number(value) > 0;
             })
             .test('max-value', t('ERROR.IS_TOO_HIGH', { name: 'Fee' }), (value) => {
-                return Number(value) < 1;
+                return Number(value) <= 1;
             })
             .trim(),
         delegateAddress: string()

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -1,25 +1,26 @@
-import assert from 'assert';
-import { useTranslation } from 'react-i18next';
-import { useEffect, useMemo, useState } from 'react';
-import { useFormik } from 'formik';
-import { BigNumber } from '@ardenthq/sdk-helpers';
 import { object, string } from 'yup';
-import { runtime } from 'webextension-polyfill';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+
+import { BigNumber } from '@ardenthq/sdk-helpers';
+import { DelegatesList } from '@/components/vote/DelegatesList';
+import { DelegatesSearchInput } from '@/components/vote/DelegatesSearchInput';
+import { Footer } from '@/shared/components/layout/Footer';
+import { ScreenName } from '@/lib/background/contracts';
 import SubPageLayout from '@/components/settings/SubPageLayout';
+import { VoteButton } from '@/components/vote/VoteButton';
+import { VoteFee } from '@/components/vote/VoteFee';
+import assert from 'assert';
+import { assertWallet } from '@/lib/utils/assertions';
+import constants from '@/constants';
+import { runtime } from 'webextension-polyfill';
 import { useDelegates } from '@/lib/hooks/useDelegates';
 import { useEnvironmentContext } from '@/lib/context/Environment';
+import { useFormik } from 'formik';
+import { useNavigate } from 'react-router-dom';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
-import { assertWallet } from '@/lib/utils/assertions';
-import { DelegatesList } from '@/components/vote/DelegatesList';
-import { VoteButton } from '@/components/vote/VoteButton';
-import { DelegatesSearchInput } from '@/components/vote/DelegatesSearchInput';
-import constants from '@/constants';
-import { Footer } from '@/shared/components/layout/Footer';
-import { VoteFee } from '@/components/vote/VoteFee';
-import { ScreenName } from '@/lib/background/contracts';
-import { useVote } from '@/lib/hooks/useVote';
 import { useProfileContext } from '@/lib/context/Profile';
+import { useTranslation } from 'react-i18next';
+import { useVote } from '@/lib/hooks/useVote';
 
 export type VoteFormik = {
     delegateAddress?: string;
@@ -74,7 +75,7 @@ const Vote = () => {
                 return Number(value) > 0;
             })
             .test('max-value', t('ERROR.IS_TOO_HIGH', { name: 'Fee' }), (value) => {
-                return Number(value) <= 1;
+                return Number(value) <= constants.MAX_FEES.vote;
             })
             .trim(),
         delegateAddress: string()

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -1,7 +1,12 @@
+import assert from 'assert';
 import { object, string } from 'yup';
 import { useEffect, useMemo, useState } from 'react';
 
 import { BigNumber } from '@ardenthq/sdk-helpers';
+import { runtime } from 'webextension-polyfill';
+import { useFormik } from 'formik';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { DelegatesList } from '@/components/vote/DelegatesList';
 import { DelegatesSearchInput } from '@/components/vote/DelegatesSearchInput';
 import { Footer } from '@/shared/components/layout/Footer';
@@ -9,17 +14,12 @@ import { ScreenName } from '@/lib/background/contracts';
 import SubPageLayout from '@/components/settings/SubPageLayout';
 import { VoteButton } from '@/components/vote/VoteButton';
 import { VoteFee } from '@/components/vote/VoteFee';
-import assert from 'assert';
 import { assertWallet } from '@/lib/utils/assertions';
 import constants from '@/constants';
-import { runtime } from 'webextension-polyfill';
 import { useDelegates } from '@/lib/hooks/useDelegates';
 import { useEnvironmentContext } from '@/lib/context/Environment';
-import { useFormik } from 'formik';
-import { useNavigate } from 'react-router-dom';
 import { usePrimaryWallet } from '@/lib/hooks/usePrimaryWallet';
 import { useProfileContext } from '@/lib/context/Profile';
-import { useTranslation } from 'react-i18next';
 import { useVote } from '@/lib/hooks/useVote';
 
 export type VoteFormik = {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[votes] using "fast" fee preset disables Vote button](https://app.clickup.com/t/86dttwpku)

## Summary

- We now validate that the' fee' is equal or lower than `1`.

<img width="362" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/0728032b-46e3-4ecb-a115-7e051599397f">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
