### PR TITLE
refactor: group amount fields in action body

### DIFF
--- a/src/components/approve/ActionBody.tsx
+++ b/src/components/approve/ActionBody.tsx
@@ -114,7 +114,7 @@ export const ActionBody = ({
                     network={network}
                 />
             )}
-            
+
             {memo && (
                 <ActionBodyRow
                     label={t('COMMON.MEMO')}

--- a/src/components/approve/ActionBody.tsx
+++ b/src/components/approve/ActionBody.tsx
@@ -66,6 +66,14 @@ export const ActionBody = ({
         <ActionDetails className={actionDetailsClassName}>
             {isApproved && <ActionAddressRow label={t('COMMON.SENDER')} address={sender ?? ''} />}
 
+            {receiver && (
+                <ActionAddressRow
+                    label={t('COMMON.RECEIVER')}
+                    address={receiver}
+                    displayAddressBookName
+                />
+            )}
+
             {amount !== undefined && convertedAmount !== undefined && (
                 <ActionAmountRow
                     label={t('COMMON.AMOUNT')}
@@ -75,22 +83,6 @@ export const ActionBody = ({
                     exchangeCurrency={exchangeCurrency}
                     network={network}
                     amountTicker={amountTicker}
-                />
-            )}
-
-            {receiver && (
-                <ActionAddressRow
-                    label={t('COMMON.RECEIVER')}
-                    address={receiver}
-                    displayAddressBookName
-                />
-            )}
-            {memo && (
-                <ActionBodyRow
-                    label={t('COMMON.MEMO')}
-                    value={memo}
-                    className='truncate pl-20'
-                    tooltipContent={memo}
                 />
             )}
 
@@ -120,6 +112,15 @@ export const ActionBody = ({
                     showFiat={showFiat}
                     exchangeCurrency={exchangeCurrency}
                     network={network}
+                />
+            )}
+            
+            {memo && (
+                <ActionBodyRow
+                    label={t('COMMON.MEMO')}
+                    value={memo}
+                    className='truncate pl-20'
+                    tooltipContent={memo}
                 />
             )}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transaction] swap Amount and Receiver on approval and approved pages](https://app.clickup.com/t/86dtu5kga)

## Summary

- Amount-type fields are now grouped in approval and approved pages.

<img width="367" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/a261b4df-c5a0-41b8-80fc-5e231614ed4e">

<img width="365" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/f142dcdf-83e9-4ecd-8325-bde95f494503">

<img width="365" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/7f7ffa5c-15e7-46f9-ad2e-4c5976ea0137">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
