### PR TITLE
refactor: update amount badge styles

### DIFF
--- a/src/components/transaction/details/AmountBadge.tsx
+++ b/src/components/transaction/details/AmountBadge.tsx
@@ -39,7 +39,7 @@ export const AmountBadge = ({
                     <div
                         className={cn('px-1.5 py-1.5 dark:text-white', {
                             'dark:bg-theme-secondary-600': type === 'default',
-                            'dark:bg-theme-green-700': type === 'positive',
+                            'dark:bg-[#307845]': type === 'positive',
                             'bg-theme-warning-150 text-theme-warning-750 dark:bg-theme-error-350':
                                 type === 'negative',
                         })}

--- a/src/components/transaction/details/AmountBadge.tsx
+++ b/src/components/transaction/details/AmountBadge.tsx
@@ -27,7 +27,7 @@ export const AmountBadge = ({
                 {
                     'border-theme-secondary-100 bg-theme-secondary-100 text-theme-secondary-500 dark:border-theme-secondary-600 dark:bg-transparent dark:text-theme-secondary-300':
                         type === 'default',
-                    'border-theme-green-100 bg-theme-green-100 text-theme-green-700 dark:border-theme-green-700 dark:bg-transparent dark:text-theme-green-600':
+                    'border-[#E2F0E6] bg-[#E2F0E6] text-[#307845] dark:border-[#307845] dark:bg-transparent dark:text-[#42B263]':
                         type === 'positive',
                     'border-theme-warning-75 bg-theme-warning-75 text-theme-warning-750 dark:border-theme-error-350 dark:bg-transparent dark:text-theme-error-300':
                         type === 'negative',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transaction details] received colours do not match designs](https://app.clickup.com/t/86dtu6d7x)

## Summary

- Colors used for amount badge have been updated to match the designs.

<img width="345" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/7a0c26c9-f212-49f8-8eea-35af47426ab8">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
