### PR TITLE
fix: display sender full address

### DIFF
--- a/src/pages/VoteApproved.tsx
+++ b/src/pages/VoteApproved.tsx
@@ -10,7 +10,6 @@ import formatDomain from '@/lib/utils/formatDomain';
 import { useProfileContext } from '@/lib/context/Profile';
 import { WalletNetwork } from '@/lib/store/wallet';
 import { ActionBody } from '@/components/approve/ActionBody';
-import trimAddress from '@/lib/utils/trimAddress';
 import getActiveCoin from '@/lib/utils/getActiveCoin';
 import { useConfirmedTransaction } from '@/lib/hooks/useConfirmedTransaction';
 import { ApproveLayout } from '@/components/approve/ApproveLayout';
@@ -136,7 +135,7 @@ const VoteApproved = () => {
                     <ActionBody
                         isApproved
                         wallet={wallet}
-                        sender={trimAddress(state?.vote.sender ?? '', 10)}
+                        sender={state?.vote.sender}
                         showFiat={showFiat}
                         fee={state?.vote.fee}
                         convertedFee={state?.vote.convertedFee as number}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[vote approved] Sender tooltip doesn't display full address](https://app.clickup.com/t/86dtu5mqh)

## Summary

- Sender full address will now be displayed in the tooltip on approved transaction pages.

<img width="370" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/26411e96-b87c-48e3-89cb-2db869c61d80">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
