### PR TITLE
refactor: display transaction

### DIFF
--- a/src/components/approve/ActionBody.blocks.tsx
+++ b/src/components/approve/ActionBody.blocks.tsx
@@ -100,7 +100,7 @@ export const ActionTransactionIdRow = ({ transactionId }: { transactionId: strin
     return (
         <ActionDetailsRow label={t('COMMON.TRANSACTION_ID')} className='items-center'>
             <div className='flex items-center gap-1'>
-                <Tooltip content={transactionId} className='break-words w-72' >
+                <Tooltip content={transactionId} className='w-72 break-words'>
                     <ActionDetailsValue>{trimAddress(transactionId, 'short')}</ActionDetailsValue>
                 </Tooltip>
 

--- a/src/components/approve/ActionBody.blocks.tsx
+++ b/src/components/approve/ActionBody.blocks.tsx
@@ -98,9 +98,11 @@ export const ActionTransactionIdRow = ({ transactionId }: { transactionId: strin
     const { t } = useTranslation();
 
     return (
-        <ActionDetailsRow label={t('COMMON.TRANSACTION_ID')}>
+        <ActionDetailsRow label={t('COMMON.TRANSACTION_ID')} className='items-center'>
             <div className='flex items-center gap-1'>
-                <ActionDetailsValue>{trimAddress(transactionId, 'short')}</ActionDetailsValue>
+                <Tooltip content={transactionId} className='break-words w-72' >
+                    <ActionDetailsValue>{trimAddress(transactionId, 'short')}</ActionDetailsValue>
+                </Tooltip>
 
                 <CopyTransactionId transactionId={transactionId} />
             </div>

--- a/src/components/approve/ActionDetails.tsx
+++ b/src/components/approve/ActionDetails.tsx
@@ -5,14 +5,16 @@ export const ActionDetailsRow = ({
     label,
     children,
     below,
+    className,
 }: {
     label: string | React.ReactNode;
     children: string | React.ReactNode;
     below?: React.ReactNode;
+    className?: string;
 }) => {
     return (
         <div className='flex flex-col space-y-1 border-b border-solid border-b-theme-secondary-100 p-3 last:border-b-0 dark:border-b-theme-secondary-700'>
-            <div className='flex justify-between'>
+            <div className={cn('flex justify-between', className)}>
                 <div className='text-sm text-theme-secondary-500 dark:text-theme-secondary-300'>
                     {label}
                 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[Vote] hovering over transaction id doesn't display tooltip](https://app.clickup.com/t/86dtuk4ap)

## Summary

- `ActionDetailsRow` component has been refactored and now accepts custom class names.
- A tooltip is now displayed with the transaction ID.

<!-- What changes are being made? -->

![image](https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/4992b4de-3245-424d-b37d-40a480a31c77)


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
