### PR TITLE
refactor: adjust padding in latest transaction items

### DIFF
--- a/src/components/home/LatestTransactions.blocks.tsx
+++ b/src/components/home/LatestTransactions.blocks.tsx
@@ -196,7 +196,7 @@ const TransactionListItem = ({
                 </div>
 
                 <div className='flex w-full flex-row items-center justify-between'>
-                    <div className='flex flex-col gap-1'>
+                    <div className='flex flex-col gap-1.5'>
                         <span className='text-left text-base font-medium leading-tight text-light-black dark:text-white'>
                             <TransactionTitle type={type} isSender={transaction.isSent()} />
                             {type === TransactionType.MULTIPAYMENT && (


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[home] increase space between transaction header and details by 2px](https://app.clickup.com/t/86dtuyvnm)

## Summary

- The space between the header and the details in the latest transaction item has been increased by 2px.

<img width="359" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/b3bbc8bd-7aea-49fb-b16d-316aa0c7a1a8">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
