### PR TITLE
fix: custom fee on Ledger pages

### DIFF
--- a/src/components/ledger/ApproveWithLedger.blocks.tsx
+++ b/src/components/ledger/ApproveWithLedger.blocks.tsx
@@ -29,7 +29,7 @@ interface Props {
 }
 
 export const VoteLedgerApprovalBody = ({ wallet, state }: Props) => {
-    const { session, amount, receiverAddress } = state;
+    const { session, amount, receiverAddress, fee: customFee } = state;
 
     const {
         values: { hasHigherCustomFee, hasLowerCustomFee },
@@ -37,6 +37,7 @@ export const VoteLedgerApprovalBody = ({ wallet, state }: Props) => {
         session,
         amount: amount ?? 0,
         receiverAddress,
+        customFee,
     });
 
     const { convert } = useExchangeRate({
@@ -53,7 +54,7 @@ export const VoteLedgerApprovalBody = ({ wallet, state }: Props) => {
             isApproved={false}
             showFiat={wallet.network().isLive()}
             wallet={wallet}
-            fee={fee}
+            fee={customFee || fee}
             convertedFee={convert(fee)}
             exchangeCurrency={wallet.exchangeCurrency() ?? 'USD'}
             network={getNetworkCurrency(wallet.network())}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] Ledger transactions displaying incorrect fees](https://app.clickup.com/t/86dtv00fu)

## Summary

- Custom fees are now being displayed on Ledger approval pages.
- Low/high fee alerts are now displayed on Ledger pages.

<img width="366" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/750aa7b2-4a2e-4e6a-8aec-346b45991736">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
