### PR TITLE
refactor: ledger signature approval page

### DIFF
--- a/src/components/approve/RequestedSignatureMessage.tsx
+++ b/src/components/approve/RequestedSignatureMessage.tsx
@@ -1,10 +1,12 @@
 import { useTranslation } from 'react-i18next';
+import { twMerge } from 'tailwind-merge';
 
 type Props = {
     data: { [key: string]: number | string };
+    className?: string;
 };
 
-const RequestedSignatureMessage = ({ data }: Props) => {
+const RequestedSignatureMessage = ({ data, className }: Props) => {
     const { t } = useTranslation();
 
     return (
@@ -13,7 +15,7 @@ const RequestedSignatureMessage = ({ data }: Props) => {
                 {t('COMMON.MESSAGE')}
             </div>
 
-            <div className='custom-scroll flex min-h-60 w-full flex-1 overflow-auto rounded-lg border border-solid border-theme-secondary-200 bg-white p-3 text-light-black dark:border-theme-secondary-700 dark:bg-subtle-black dark:text-white'>
+            <div className={twMerge('custom-scroll flex min-h-60 w-full flex-1 overflow-auto rounded-lg border border-solid border-theme-secondary-200 bg-white p-3 text-light-black dark:border-theme-secondary-700 dark:bg-subtle-black dark:text-white', className)}>
                 {data.message}
             </div>
         </div>

--- a/src/components/ledger/ApproveWithLedger.blocks.tsx
+++ b/src/components/ledger/ApproveWithLedger.blocks.tsx
@@ -67,7 +67,6 @@ export const VoteLedgerApprovalBody = ({ wallet, state }: Props) => {
                 publicKey: vote?.wallet?.publicKey(),
                 address: vote?.wallet?.address(),
             }}
-            actionDetailsClassName='max-h-81.5'
             hasHigherCustomFee={hasHigherCustomFee}
             amountTicker={wallet.currency()}
         />
@@ -118,8 +117,6 @@ export const SignatureLedgerApprovalBody = () => {
     const { state } = location;
 
     return (
-        <div className='h-[191px]'>
-            <RequestedSignatureMessage data={state} />
-        </div>
+        <RequestedSignatureMessage data={state} className='min-h-[194px]' />
     );
 };

--- a/src/components/ledger/ApproveWithLedger.tsx
+++ b/src/components/ledger/ApproveWithLedger.tsx
@@ -10,7 +10,7 @@ import {
 import formatDomain from '@/lib/utils/formatDomain';
 import trimAddress from '@/lib/utils/trimAddress';
 import { ApproveActionType } from '@/pages/Approve';
-import { Heading, HeadingDescription, Icon, Loader } from '@/shared/components';
+import { ArrowButton, Heading, HeadingDescription, Icon, Loader } from '@/shared/components';
 import RequestedBy from '@/shared/components/actions/RequestedBy';
 import { NavButton } from '@/shared/components/nav/NavButton';
 import { useLedgerConnectionStatusMessage } from '@/lib/Ledger';
@@ -62,29 +62,12 @@ const ApproveWithLedger = ({
         }
     };
 
-    const getTopMarginClass = () => {
-        switch (actionType) {
-            case ApproveActionType.VOTE:
-            case ApproveActionType.UNVOTE:
-                return 'mt-20';
-            case ApproveActionType.SWITCH_VOTE:
-                return 'mt-11';
-            default:
-                return 'mt-6';
-        }
-    };
-
     return (
         <div className='flex max-h-screen min-h-screen flex-col overflow-auto bg-subtle-white dark:bg-light-black'>
             <RequestedBy appDomain={formatDomain(appName) || ''} appLogo={appLogo} />
-            <div className='flex flex-1 flex-col overflow-auto px-4 pt-4'>
+            <div className='flex flex-1 flex-col overflow-auto px-4 py-4 custom-scroll'>
                 <div className='flex items-center justify-between gap-3 bg-subtle-white dark:bg-light-black'>
-                    <NavButton onClick={handleBackButtonClick}>
-                        <Icon
-                            icon='arrow-left'
-                            className='h-4.5 w-4.5 text-theme-primary-700 dark:text-theme-primary-650'
-                        />
-                    </NavButton>
+                    <ArrowButton onClick={handleBackButtonClick} />
                 </div>
                 <Heading className='mb-2 mt-4' level={3}>
                     {t('PAGES.IMPORT_WITH_LEDGER.CONNECT_LEDGER_AND_SIGN_THE_REQUEST', {
@@ -94,7 +77,7 @@ const ApproveWithLedger = ({
                 <HeadingDescription>
                     {t('PAGES.IMPORT_WITH_LEDGER.CONNECT_YOUR_LEDGER_DEVICE_DISCLAIMER')}
                 </HeadingDescription>
-                <div className='mt-6 flex flex-1 flex-col overflow-auto'>
+                <div className='mt-6 flex flex-1 flex-col'>
                     {votingActionTypes.includes(actionType) && (
                         <VoteLedgerApprovalBody wallet={wallet} state={state} />
                     )}
@@ -103,9 +86,11 @@ const ApproveWithLedger = ({
                     )}
                     {actionType === ApproveActionType.SIGNATURE && <SignatureLedgerApprovalBody />}
                 </div>
+            </div>
 
-                <div className={twMerge('mb-6', getTopMarginClass())}>
-                    <div className='overflow-hidden rounded-2xl border border-solid border-theme-warning-400'>
+
+            <div className='flex-none bg-white dark:bg-subtle-black'>
+                    <div className='m-4 overflow-hidden rounded-2xl border border-solid border-theme-warning-400'>
                         {!!address && (
                             <div className='flex justify-center bg-white p-[14px] dark:bg-light-black'>
                                 <p className='typeset-headline text-light-black dark:text-white'>
@@ -123,7 +108,6 @@ const ApproveWithLedger = ({
                         </div>
                     </div>
                 </div>
-            </div>
         </div>
     );
 };

--- a/src/components/ledger/ApproveWithLedger.tsx
+++ b/src/components/ledger/ApproveWithLedger.tsx
@@ -1,6 +1,5 @@
 import { Contracts } from '@ardenthq/sdk-profiles';
 import { useTranslation } from 'react-i18next';
-import { twMerge } from 'tailwind-merge';
 import { useLocation } from 'react-router-dom';
 import {
     SignatureLedgerApprovalBody,
@@ -10,9 +9,8 @@ import {
 import formatDomain from '@/lib/utils/formatDomain';
 import trimAddress from '@/lib/utils/trimAddress';
 import { ApproveActionType } from '@/pages/Approve';
-import { ArrowButton, Heading, HeadingDescription, Icon, Loader } from '@/shared/components';
+import { ArrowButton, Heading, HeadingDescription, Loader } from '@/shared/components';
 import RequestedBy from '@/shared/components/actions/RequestedBy';
-import { NavButton } from '@/shared/components/nav/NavButton';
 import { useLedgerConnectionStatusMessage } from '@/lib/Ledger';
 
 type Props = {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[signature] adjust padding in signature request](https://app.clickup.com/t/86dtv27vg)

## Summary

- Paddings in Ledger signature approval page has been refactored to match the other screens.
- Additional refactor for `ApproveWithLedger` page.

<img width="362" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/1b4f5965-935d-49ab-8fa2-ae21c1851ab5">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
