### PR TITLE
refactor: persistence for vote/transfer pages on error pages

### DIFF
--- a/src/components/approve/ApproveTransaction.tsx
+++ b/src/components/approve/ApproveTransaction.tsx
@@ -185,7 +185,7 @@ const ApproveTransaction = ({
                     memo,
                     fee: customFee,
                     receiverAddress,
-                }
+                },
             });
             loadingModal.close();
         }

--- a/src/components/approve/ApproveVote.tsx
+++ b/src/components/approve/ApproveVote.tsx
@@ -180,7 +180,7 @@ const ApproveVote = ({ abortReference, approveWithLedger, wallet, closeLedgerScr
                 data: {
                     fee: customFee,
                     delegateAddress: vote?.wallet?.address() || unvote?.wallet?.address(),
-                }
+                },
             });
             loadingModal.close();
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] retain transaction information on error pages](https://app.clickup.com/t/86dtwzzr3)

## Summary

- When clicking `Back` button on error pages, the info from the form persists. 

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
