### PR TITLE
refactor: add version link to release log

### DIFF
--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -1,13 +1,14 @@
 import { runtime } from 'webextension-polyfill';
 import { useTranslation } from 'react-i18next';
 import SubPageLayout from '@/components/settings/SubPageLayout';
-import { Icon, RowLayout } from '@/shared/components';
+import { Button, ExternalLink, Icon, RowLayout } from '@/shared/components';
 import useClipboard from '@/lib/hooks/useClipboard';
 import constants from '@/constants';
 
 const AboutARK = () => {
     const { copy } = useClipboard();
     const { t } = useTranslation();
+    const version = runtime.getManifest().version;
 
     const copyEmailToClipboard = (evt: React.MouseEvent<HTMLButtonElement>) => {
         evt.stopPropagation();
@@ -29,9 +30,13 @@ const AboutARK = () => {
                         className='h-[21px] w-[228px] text-theme-primary-700 dark:text-theme-primary-650'
                     />
                 </div>
-                <p className='typeset-body text-theme-secondary-500 dark:text-theme-secondary-300'>
-                    {t('MISC.VERSION')} {runtime.getManifest().version}
-                </p>
+                <ExternalLink href={`${constants.GITHUB_RELEASES_URL}${version}`} tabIndex={-1}>
+                    <Button iconTrailing='link-external' variant='secondaryLink' className='text-theme-secondary-500 dark:text-theme-secondary-300'>
+                        <span className='typeset-body font-normal'>
+                            {t('MISC.VERSION')} {version}
+                        </span>
+                    </Button>
+                </ExternalLink>
             </div>
 
             <div className='flex flex-col gap-2 text-light-black dark:text-white'>

--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -1,9 +1,10 @@
-import { runtime } from 'webextension-polyfill';
-import { useTranslation } from 'react-i18next';
-import SubPageLayout from '@/components/settings/SubPageLayout';
 import { Button, ExternalLink, Icon, RowLayout } from '@/shared/components';
-import useClipboard from '@/lib/hooks/useClipboard';
+
 import constants from '@/constants';
+import { runtime } from 'webextension-polyfill';
+import SubPageLayout from '@/components/settings/SubPageLayout';
+import useClipboard from '@/lib/hooks/useClipboard';
+import { useTranslation } from 'react-i18next';
 
 const AboutARK = () => {
     const { copy } = useClipboard();
@@ -32,7 +33,7 @@ const AboutARK = () => {
                 </div>
                 <ExternalLink href={`${constants.GITHUB_RELEASES_URL}${version}`} tabIndex={-1}>
                     <Button iconTrailing='link-external' variant='secondaryLink' className='group'>
-                        <span className='typeset-body transiton-smoothEase font-normal text-theme-secondary-500 group-hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:group-hover:text-theme-primary-700'>
+                        <span className='typeset-body transition-smoothEase font-normal text-theme-secondary-500 group-hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:group-hover:text-theme-primary-700'>
                             {t('MISC.VERSION')} {version}
                         </span>
                     </Button>

--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -1,10 +1,10 @@
+import { runtime } from 'webextension-polyfill';
+import { useTranslation } from 'react-i18next';
 import { Button, ExternalLink, Icon, RowLayout } from '@/shared/components';
 
 import constants from '@/constants';
-import { runtime } from 'webextension-polyfill';
 import SubPageLayout from '@/components/settings/SubPageLayout';
 import useClipboard from '@/lib/hooks/useClipboard';
-import { useTranslation } from 'react-i18next';
 
 const AboutARK = () => {
     const { copy } = useClipboard();

--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -31,12 +31,8 @@ const AboutARK = () => {
                     />
                 </div>
                 <ExternalLink href={`${constants.GITHUB_RELEASES_URL}${version}`} tabIndex={-1}>
-                    <Button
-                        iconTrailing='link-external'
-                        variant='secondaryLink'
-                        className='group'
-                    >
-                        <span className='typeset-body font-normal text-theme-secondary-500 dark:text-theme-secondary-300 group-hover:text-theme-primary-700 dark:group-hover:text-theme-primary-700 transiton-smoothEase'>
+                    <Button iconTrailing='link-external' variant='secondaryLink' className='group'>
+                        <span className='typeset-body transiton-smoothEase font-normal text-theme-secondary-500 group-hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:group-hover:text-theme-primary-700'>
                             {t('MISC.VERSION')} {version}
                         </span>
                     </Button>

--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -31,7 +31,11 @@ const AboutARK = () => {
                     />
                 </div>
                 <ExternalLink href={`${constants.GITHUB_RELEASES_URL}${version}`} tabIndex={-1}>
-                    <Button iconTrailing='link-external' variant='secondaryLink' className='text-theme-secondary-500 dark:text-theme-secondary-300'>
+                    <Button
+                        iconTrailing='link-external'
+                        variant='secondaryLink'
+                        className='text-theme-secondary-500 dark:text-theme-secondary-300'
+                    >
                         <span className='typeset-body font-normal'>
                             {t('MISC.VERSION')} {version}
                         </span>

--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -34,9 +34,8 @@ const AboutARK = () => {
                     <Button
                         iconTrailing='link-external'
                         variant='secondaryLink'
-                        className='text-theme-secondary-500 dark:text-theme-secondary-300'
                     >
-                        <span className='typeset-body font-normal'>
+                        <span className='typeset-body font-normal text-theme-secondary-500 dark:text-theme-secondary-300 hover:text-theme-primary-700 transiton-smoothEase'>
                             {t('MISC.VERSION')} {version}
                         </span>
                     </Button>

--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -34,8 +34,9 @@ const AboutARK = () => {
                     <Button
                         iconTrailing='link-external'
                         variant='secondaryLink'
+                        className='group'
                     >
-                        <span className='typeset-body font-normal text-theme-secondary-500 dark:text-theme-secondary-300 hover:text-theme-primary-700 transiton-smoothEase'>
+                        <span className='typeset-body font-normal text-theme-secondary-500 dark:text-theme-secondary-300 group-hover:text-theme-primary-700 dark:group-hover:text-theme-primary-700 transiton-smoothEase'>
                             {t('MISC.VERSION')} {version}
                         </span>
                     </Button>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,7 @@ const ARK_CONNECT_DEMO = 'https://demo.arkconnect.io';
 const ARKVAULT_BASE_URL = 'https://app.arkvault.io/';
 const ARKVAULT_API_MAINNET_BASE_URL = 'https://api.ark.io/';
 const ARKVAULT_API_DEVNET_BASE_URL = 'https://ark-test.arkvault.io/';
+const GITHUB_RELEASES_URL = 'https://github.com/ArdentHQ/arkconnect-extension/releases/tag/';
 
 const SHOW_MESSAGE_AFTER_ACTION_DURING_MS = 3000;
 
@@ -57,6 +58,7 @@ const constants = {
     AMOUNT_REGEX,
     MAX_FEES,
     FEE_REGEX,
+    GITHUB_RELEASES_URL,
 };
 
 export default constants;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[about] add version link](https://app.clickup.com/t/86du13mfv)

## Summary

- `GITHUB_RELEASES_URL` has been added to the constants file.
- A link to the release log for current version has been added to the `About` page.

<img width="363" alt="image" src="https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/ff1f645f-7346-4fba-ae9b-b72b33b20c42">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
