### PR TITLE
feat: add shortcut to extension

### DIFF
--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -14,7 +14,7 @@
     "background": {
         "service_worker": "src/background.ts"
     },
-    "permissions": ["activeTab", "storage", "clipboardWrite", "tabs", "unlimitedStorage"],
+    "permissions": ["activeTab", "storage", "clipboardWrite", "tabs", "unlimitedStorage", "commands"],
     "content_scripts": [
         {
             "matches": ["https://*/*"],
@@ -27,5 +27,13 @@
             "resources": ["src/inpage.js"],
             "matches": ["<all_urls>"]
         }
-    ]
+    ],
+    "commands": {
+        "_execute_action": {
+            "suggested_key": {
+                "default": "Shift+Alt+A"
+            },
+            "description": "Open the extension"
+        }
+    }
 }

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -14,7 +14,14 @@
     "background": {
         "service_worker": "src/background.ts"
     },
-    "permissions": ["activeTab", "storage", "clipboardWrite", "tabs", "unlimitedStorage", "commands"],
+    "permissions": [
+        "activeTab",
+        "storage",
+        "clipboardWrite",
+        "tabs",
+        "unlimitedStorage",
+        "commands"
+    ],
     "content_scripts": [
         {
             "matches": ["https://*/*"],

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -15,7 +15,14 @@
         "scripts": ["src/background.ts"],
         "persistent": true
     },
-    "permissions": ["activeTab", "storage", "clipboardWrite", "tabs", "unlimitedStorage", "commands"],
+    "permissions": [
+        "activeTab",
+        "storage",
+        "clipboardWrite",
+        "tabs",
+        "unlimitedStorage",
+        "commands"
+    ],
     "content_scripts": [
         {
             "matches": ["https://*/*"],

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -15,7 +15,7 @@
         "scripts": ["src/background.ts"],
         "persistent": true
     },
-    "permissions": ["activeTab", "storage", "clipboardWrite", "tabs", "unlimitedStorage"],
+    "permissions": ["activeTab", "storage", "clipboardWrite", "tabs", "unlimitedStorage", "commands"],
     "content_scripts": [
         {
             "matches": ["https://*/*"],
@@ -23,5 +23,13 @@
             "run_at": "document_start"
         }
     ],
-    "web_accessible_resources": ["src/inpage.js"]
+    "web_accessible_resources": ["src/inpage.js"],
+    "commands": {
+        "_execute_browser_action": {
+            "suggested_key": {
+                "default": "Shift+Alt+A"
+            },
+            "description": "Open the extension"
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] add shortcut to extension](https://app.clickup.com/t/86du1ed1w)

## Summary

- A new shortcut has been added to both of our web manifest. The extension will now open using `Shift + Alt + A` on Windows and `Shift + Option + A` on Mac.

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/cd26bd83-41fa-4187-b183-8f04245eed6e



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
