### PR TITLE
fix: prevent theme from changing when addresses are removed

### DIFF
--- a/src/lib/hooks/useResetExtension.ts
+++ b/src/lib/hooks/useResetExtension.ts
@@ -4,7 +4,7 @@ import useOnError from '.';
 import { useProfileContext } from '@/lib/context/Profile';
 import { revertAll } from '@/lib/store/ui';
 import { useAppDispatch } from '@/lib/store';
-import { clearLocalStorage } from '@/lib/utils/localStorage';
+import { clearLocalStorage, softClearLocalStorage } from '@/lib/utils/localStorage';
 
 const useResetExtension = () => {
     const dispatch = useAppDispatch();
@@ -42,7 +42,19 @@ const useResetExtension = () => {
         }
     };
 
-    return resetExtension;
+    const softResetExtension = async () => {
+        try {
+            navigate('/splash-screen');
+
+            await Promise.all([resetEnvironment(), softClearLocalStorage()]);
+
+            await initProfile();
+        } catch (error) {
+            onError(error);
+        }
+    };
+
+    return {resetExtension, softResetExtension};
 };
 
 export default useResetExtension;

--- a/src/lib/hooks/useResetExtension.ts
+++ b/src/lib/hooks/useResetExtension.ts
@@ -54,7 +54,7 @@ const useResetExtension = () => {
         }
     };
 
-    return {resetExtension, softResetExtension};
+    return { resetExtension, softResetExtension };
 };
 
 export default useResetExtension;

--- a/src/lib/store/ui/index.ts
+++ b/src/lib/store/ui/index.ts
@@ -60,7 +60,7 @@ export const uiSlice = createSlice({
             state.locked = action.payload;
         },
     },
-    extraReducers: (builder) => builder.addCase(revertAll, () => initialState)
+    extraReducers: (builder) => builder.addCase(revertAll, () => initialState),
 });
 
 export const {

--- a/src/lib/store/ui/index.ts
+++ b/src/lib/store/ui/index.ts
@@ -60,7 +60,12 @@ export const uiSlice = createSlice({
             state.locked = action.payload;
         },
     },
-    extraReducers: (builder) => builder.addCase(revertAll, () => initialState),
+    extraReducers: (builder) => {
+        builder.addCase(revertAll, (state) => {
+            const currentThemeAccent = state.themeAccent;
+            Object.assign(state, initialState, { themeAccent: currentThemeAccent });
+        });
+    },
 });
 
 export const {

--- a/src/lib/store/ui/index.ts
+++ b/src/lib/store/ui/index.ts
@@ -60,12 +60,7 @@ export const uiSlice = createSlice({
             state.locked = action.payload;
         },
     },
-    extraReducers: (builder) => {
-        builder.addCase(revertAll, (state) => {
-            const currentThemeAccent = state.themeAccent;
-            Object.assign(state, initialState, { themeAccent: currentThemeAccent });
-        });
-    },
+    extraReducers: (builder) => builder.addCase(revertAll, () => initialState)
 });
 
 export const {

--- a/src/lib/utils/localStorage.ts
+++ b/src/lib/utils/localStorage.ts
@@ -56,3 +56,10 @@ export const setLocalValue = async (
 export const clearLocalStorage = async () => {
     await storage.local.remove(KEY);
 };
+
+export const softClearLocalStorage = async () => {
+    const { autoLockTimer } = await parseLocalStorageValues();
+
+    await storage.local.clear();
+    await storage.local.set({ [KEY]: { autoLockTimer } });
+};

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -5,7 +5,7 @@ import SubPageLayout from '@/components/settings/SubPageLayout';
 import useResetExtension from '@/lib/hooks/useResetExtension';
 
 const ForgotPassword = () => {
-    const resetExtension = useResetExtension();
+    const { resetExtension } = useResetExtension();
     const [lostPasswordAwareness, setLostPasswordAwareness] = useState<boolean>(false);
     const { t } = useTranslation();
 

--- a/src/pages/Logout.tsx
+++ b/src/pages/Logout.tsx
@@ -26,7 +26,7 @@ const Logout = () => {
     const sessions = useAppSelector(SessionStore.selectSessions);
     const { onError } = useErrorHandlerContext();
     const walletsIds = useAppSelector(WalletStore.selectWalletsIds);
-    const resetExtension = useResetExtension();
+    const { softResetExtension } = useResetExtension();
     const { t } = useTranslation();
     const walletsToLogout = location.state;
 
@@ -67,7 +67,7 @@ const Logout = () => {
             });
 
             if (noWallets) {
-                await resetExtension();
+                await softResetExtension();
                 await initProfile();
                 return;
             }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] prevent theme from changing to blue when wallets are deleted](https://app.clickup.com/t/86du1qy9a)

## Summary

- The theme color won't change when all the addresses are removed from the wallet.

<!-- What changes are being made? -->

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/fdf7c7a1-7a15-4590-9783-af4ece3adb43



<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
