### PR TITLE
fix: version link firefox

### DIFF
--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -1,7 +1,6 @@
 import { runtime } from 'webextension-polyfill';
 import { useTranslation } from 'react-i18next';
-import cn from 'classnames';
-import { Button, ExternalLink, Icon, RowLayout } from '@/shared/components';
+import { ExternalLink, Icon, RowLayout } from '@/shared/components';
 
 import constants from '@/constants';
 import SubPageLayout from '@/components/settings/SubPageLayout';

--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -37,7 +37,7 @@ const AboutARK = () => {
                     />
                 </div>
                 <ExternalLink href={`${constants.GITHUB_RELEASES_URL}${version}`} tabIndex={-1} className='group'>
-                    <Button iconTrailing='link-external' variant='secondaryLink' className='group' iconClass={cn('w-5 h-5 group-hover:text-theme-primary-700 dark:group-hover:text-theme-primary-700 transition-smoothEase')}>
+                    <Button iconTrailing='link-external' variant='secondaryLink' iconClass={cn('w-5 h-5 group-hover:text-theme-primary-700 dark:group-hover:text-theme-primary-700 transition-smoothEase')}>
                         <span className={cn('typeset-body font-normal text-theme-secondary-500 group-hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:group-hover:text-theme-primary-700 duration-300 transition-smoothEase')}>
                             {t('MISC.VERSION')} {version}
                         </span>

--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -39,23 +39,12 @@ const AboutARK = () => {
                 <ExternalLink
                     href={`${constants.GITHUB_RELEASES_URL}${version}`}
                     tabIndex={-1}
-                    className='group'
+                    className='group flex flex-row gap-2 text-theme-secondary-500 hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:hover:text-theme-primary-700 transition-smoothEase items-center'
                 >
-                    <Button
-                        iconTrailing='link-external'
-                        variant='secondaryLink'
-                        iconClass={cn(
-                            'w-5 h-5 group-hover:text-theme-primary-700 dark:group-hover:text-theme-primary-700 transition-smoothEase',
-                        )}
-                    >
-                        <span
-                            className={cn(
-                                'typeset-body transition-smoothEase font-normal text-theme-secondary-500 group-hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:group-hover:text-theme-primary-700',
-                            )}
-                        >
-                            {t('MISC.VERSION')} {version}
-                        </span>
-                    </Button>
+                    <span className='typeset-body font-normal'>
+                        {t('MISC.VERSION')} {version}
+                    </span>
+                    <Icon icon='link-external' className='h-5 w-5 text-light-black dark:text-white group-hover:text-theme-primary-700 dark:group-hover:text-theme-primary-700 transition-smoothEase' />
                 </ExternalLink>
             </div>
 

--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -36,9 +36,23 @@ const AboutARK = () => {
                         className='h-[21px] w-[228px] text-theme-primary-700 dark:text-theme-primary-650'
                     />
                 </div>
-                <ExternalLink href={`${constants.GITHUB_RELEASES_URL}${version}`} tabIndex={-1} className='group'>
-                    <Button iconTrailing='link-external' variant='secondaryLink' iconClass={cn('w-5 h-5 group-hover:text-theme-primary-700 dark:group-hover:text-theme-primary-700 transition-smoothEase')}>
-                        <span className={cn('typeset-body font-normal text-theme-secondary-500 group-hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:group-hover:text-theme-primary-700 transition-smoothEase')}>
+                <ExternalLink
+                    href={`${constants.GITHUB_RELEASES_URL}${version}`}
+                    tabIndex={-1}
+                    className='group'
+                >
+                    <Button
+                        iconTrailing='link-external'
+                        variant='secondaryLink'
+                        iconClass={cn(
+                            'w-5 h-5 group-hover:text-theme-primary-700 dark:group-hover:text-theme-primary-700 transition-smoothEase',
+                        )}
+                    >
+                        <span
+                            className={cn(
+                                'typeset-body transition-smoothEase font-normal text-theme-secondary-500 group-hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:group-hover:text-theme-primary-700',
+                            )}
+                        >
                             {t('MISC.VERSION')} {version}
                         </span>
                     </Button>

--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -1,5 +1,6 @@
 import { runtime } from 'webextension-polyfill';
 import { useTranslation } from 'react-i18next';
+import cn from 'classnames';
 import { Button, ExternalLink, Icon, RowLayout } from '@/shared/components';
 
 import constants from '@/constants';
@@ -35,9 +36,9 @@ const AboutARK = () => {
                         className='h-[21px] w-[228px] text-theme-primary-700 dark:text-theme-primary-650'
                     />
                 </div>
-                <ExternalLink href={`${constants.GITHUB_RELEASES_URL}${version}`} tabIndex={-1}>
-                    <Button iconTrailing='link-external' variant='secondaryLink' className='group'>
-                        <span className='typeset-body transition-smoothEase font-normal text-theme-secondary-500 group-hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:group-hover:text-theme-primary-700'>
+                <ExternalLink href={`${constants.GITHUB_RELEASES_URL}${version}`} tabIndex={-1} className='group'>
+                    <Button iconTrailing='link-external' variant='secondaryLink' className='group' iconClass={cn('w-5 h-5 group-hover:text-theme-primary-700 dark:group-hover:text-theme-primary-700 transition-smoothEase')}>
+                        <span className={cn('typeset-body font-normal text-theme-secondary-500 group-hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:group-hover:text-theme-primary-700 duration-300 transition-smoothEase')}>
                             {t('MISC.VERSION')} {version}
                         </span>
                     </Button>

--- a/src/components/settings/others/AboutARK.tsx
+++ b/src/components/settings/others/AboutARK.tsx
@@ -38,7 +38,7 @@ const AboutARK = () => {
                 </div>
                 <ExternalLink href={`${constants.GITHUB_RELEASES_URL}${version}`} tabIndex={-1} className='group'>
                     <Button iconTrailing='link-external' variant='secondaryLink' iconClass={cn('w-5 h-5 group-hover:text-theme-primary-700 dark:group-hover:text-theme-primary-700 transition-smoothEase')}>
-                        <span className={cn('typeset-body font-normal text-theme-secondary-500 group-hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:group-hover:text-theme-primary-700 duration-300 transition-smoothEase')}>
+                        <span className={cn('typeset-body font-normal text-theme-secondary-500 group-hover:text-theme-primary-700 dark:text-theme-secondary-300 dark:group-hover:text-theme-primary-700 transition-smoothEase')}>
                             {t('MISC.VERSION')} {version}
                         </span>
                     </Button>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[firefox] version link transition issue on firefox](https://app.clickup.com/t/86du1zxp3)

## Summary

- Version link transition for Firefox has been fixed



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

https://github.com/ArdentHQ/arkconnect-extension/assets/55117912/36f37b22-2ac9-45c5-baa1-bfee7bd6571b


<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
