### PR TITLE
refactor: persist errors on send form

### DIFF
--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -31,6 +31,14 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
         formik.validateField('amount');
     };
 
+    const handleAmountInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const { value } = event.target;
+        if (constants.FEE_REGEX.test(value) || value === '') {
+          formik.setFieldValue('amount', value.trim());
+          formik.validateField('amount');
+        }
+      };
+
     const handleFeeInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (!constants.FEE_REGEX.test(event.target.value)) {
             return;
@@ -90,7 +98,7 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
                     </button>
                 }
                 value={formik.values.amount}
-                onChange={handleInputChange}
+                onChange={handleAmountInputChange}
                 onBlur={formik.handleBlur}
                 variant={
                     formik.errors.amount && formik.values.amount !== '' ? 'destructive' : 'primary'

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -34,10 +34,10 @@ export const SendForm = ({ formik }: { formik: FormikProps<SendFormik> }) => {
     const handleAmountInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const { value } = event.target;
         if (constants.FEE_REGEX.test(value) || value === '') {
-          formik.setFieldValue('amount', value.trim());
-          formik.validateField('amount');
+            formik.setFieldValue('amount', value.trim());
+            formik.validateField('amount');
         }
-      };
+    };
 
     const handleFeeInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (!constants.FEE_REGEX.test(event.target.value)) {

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -198,7 +198,7 @@ const Send = () => {
         runtime.sendMessage({
             type: 'SET_LAST_SCREEN',
             path: ScreenName.SendTransfer,
-            data: {errors: formik.errors, ...formik.values},
+            data: { errors: formik.errors, ...formik.values },
         });
 
         return () => {
@@ -221,7 +221,7 @@ const Send = () => {
                 formik.setFieldTouched(key, true);
             });
         }
-      }, [lastVisitedPage, formik.setFieldTouched, formik.setErrors]);
+    }, [lastVisitedPage, formik.setFieldTouched, formik.setErrors]);
 
     return (
         <SubPageLayout

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -24,6 +24,7 @@ export type SendFormik = {
     fee: string;
     receiverAddress: string;
     feeClass?: string;
+    errors?: any;
 };
 
 interface PageData extends SendFormik {
@@ -197,7 +198,7 @@ const Send = () => {
         runtime.sendMessage({
             type: 'SET_LAST_SCREEN',
             path: ScreenName.SendTransfer,
-            data: formik.values,
+            data: {errors: formik.errors, ...formik.values},
         });
 
         return () => {
@@ -211,6 +212,16 @@ const Send = () => {
     const handleModalClick = () => {
         setIsModalOpen(true);
     };
+
+    useEffect(() => {
+        const { data } = lastVisitedPage || {};
+        if (data?.errors && Object.keys(data.errors).length > 0) {
+            formik.setErrors(data.errors);
+            Object.entries(data.errors).forEach(([key]) => {
+                formik.setFieldTouched(key, true);
+            });
+        }
+      }, [lastVisitedPage, formik.setFieldTouched, formik.setErrors]);
 
     return (
         <SubPageLayout


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[send] check if possible to persist errors when opening/closing extension](https://app.clickup.com/t/86du4fgxp)

## Summary

- Errors now persist on `Send` form when we close and open the extension again.
- A regex for the amount input has been set, this was causing issues with validation when typing letters or any non-number values.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

https://github.com/user-attachments/assets/30319a60-b9aa-465e-8bd1-1be77a5f0790



<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
