### PR TITLE
fix: adjust focus color for upload qr modal

### DIFF
--- a/src/components/send/UploadQRModal.tsx
+++ b/src/components/send/UploadQRModal.tsx
@@ -138,9 +138,9 @@ export const UploadQRModal = ({
                             maxSize={5}
                             onSizeError={handleSizeError}
                             onTypeError={handleTypeError}
-                            tabIndex={-1}
+                            classes='focus-within:!outline-theme-primary-600 rounded-2xl'
                         >
-                            <Button variant='primary'>{t('PAGES.SEND.QR_MODAL.UPLOAD_QR')}</Button>
+                            <Button variant='primary' tabIndex={-1}>{t('PAGES.SEND.QR_MODAL.UPLOAD_QR')}</Button>
                         </FileUploader>
                     </div>
                 )
@@ -157,6 +157,7 @@ export const UploadQRModal = ({
                     maxSize={5}
                     onSizeError={handleSizeError}
                     onTypeError={handleTypeError}
+                    classes='focus-within:!outline-theme-primary-600 rounded-2xl'
                 >
                     <div className='h-50 w-[306px] cursor-pointer rounded-2xl border border-dashed border-theme-secondary-200 bg-theme-secondary-25 dark:border-theme-secondary-600 dark:bg-theme-secondary-800'>
                         <div className='relative flex items-center justify-center overflow-hidden'>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[QR] Upload QR Code button outline](https://app.clickup.com/t/86du4futw)

## Summary

- Focus color for the "Upload QR" button and for the drag and drop zone have been updated.

<img width="367" alt="image" src="https://github.com/user-attachments/assets/f96ead50-65d1-4f6c-b6ee-7da35b984397">

<img width="368" alt="image" src="https://github.com/user-attachments/assets/d2f71fad-88e9-49f3-a6f2-ea276d345934">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
