### PR TITLE
fix: wallet already exists error page styles

### DIFF
--- a/src/components/connect/ErrorModal.tsx
+++ b/src/components/connect/ErrorModal.tsx
@@ -22,9 +22,7 @@ const ErrorContainer = ({ error }: { error: string }) => {
 
     return (
         <div className='flex flex-col gap-4'>
-            <div
-                className='flex items-start justify-start break-all rounded-lg border border-theme-secondary-400 bg-white p-3 text-left text-base font-normal leading-5 text-light-black dark:border-theme-secondary-500 dark:bg-subtle-black dark:text-white dark:shadow-secondary-dark'
-            >
+            <div className='flex items-start justify-start break-all rounded-lg border border-theme-secondary-400 bg-white p-3 text-left text-base font-normal leading-5 text-light-black dark:border-theme-secondary-500 dark:bg-subtle-black dark:text-white dark:shadow-secondary-dark'>
                 <span className='block' dangerouslySetInnerHTML={{ __html: errorParser(error) }} />
             </div>
 

--- a/src/components/connect/ErrorModal.tsx
+++ b/src/components/connect/ErrorModal.tsx
@@ -22,10 +22,11 @@ const ErrorContainer = ({ error }: { error: string }) => {
 
     return (
         <div className='flex flex-col gap-4'>
-            <span
+            <div
                 className='flex items-start justify-start break-all rounded-lg border border-theme-secondary-400 bg-white p-3 text-left text-base font-normal leading-5 text-light-black dark:border-theme-secondary-500 dark:bg-subtle-black dark:text-white dark:shadow-secondary-dark'
-                dangerouslySetInnerHTML={{ __html: errorParser(error) }}
-            />
+            >
+                <span className='block' dangerouslySetInnerHTML={{ __html: errorParser(error) }} />
+            </div>
 
             <div className='flex w-full justify-center'>
                 <button


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[Errors] Wallet already exists page needs work](https://app.clickup.com/t/86du5ka9m)

## Summary

- Styles for HTML inserted in error pages have been updated to prevent text being displayed horizontally.

<img width="361" alt="image" src="https://github.com/user-attachments/assets/0b519306-4dd8-430b-8610-33ab4409b2e6">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
