### PR TITLE
refactor: disable qr upload button on firefox

### DIFF
--- a/src/components/send/SendModalButton.tsx
+++ b/src/components/send/SendModalButton.tsx
@@ -7,19 +7,23 @@ const SendModalButton = ({ onClick }: { onClick: MouseEventHandler<HTMLButtonEle
     const { t } = useTranslation();
 
     return (
-        <Tooltip content={t('PAGES.SEND.QR_MODAL.FIREFOX_NOT_SUPPORTED')} disabled={!isFirefox} className='w-60'>
+        <Tooltip
+            content={t('PAGES.SEND.QR_MODAL.FIREFOX_NOT_SUPPORTED')}
+            disabled={!isFirefox}
+            className='w-60'
+        >
             <div>
                 <Button
                     variant='secondaryBlack'
                     className='!h-fit !w-fit !px-3 !py-1.5 !text-sm !font-medium'
                     iconTrailing='qr-code'
                     iconClass='h-4 w-4'
-                    onClick={onClick} 
+                    onClick={onClick}
                     disabled={isFirefox}
                 >
                     {t('PAGES.SEND.QR_MODAL.UPLOAD_QR')}
                 </Button>
-            </div> 
+            </div>
         </Tooltip>
     );
 };

--- a/src/components/send/SendModalButton.tsx
+++ b/src/components/send/SendModalButton.tsx
@@ -1,20 +1,26 @@
 import { MouseEventHandler } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@/shared/components';
+import { Button, Tooltip } from '@/shared/components';
+import { isFirefox } from '@/lib/utils/isFirefox';
 
 const SendModalButton = ({ onClick }: { onClick: MouseEventHandler<HTMLButtonElement> }) => {
     const { t } = useTranslation();
 
     return (
-        <Button
-            variant='secondaryBlack'
-            className='!h-fit !w-fit !px-3 !py-1.5 !text-sm !font-medium'
-            iconTrailing='qr-code'
-            iconClass='h-4 w-4'
-            onClick={onClick}
-        >
-            {t('PAGES.SEND.QR_MODAL.UPLOAD_QR')}
-        </Button>
+        <Tooltip content={t('PAGES.SEND.QR_MODAL.FIREFOX_NOT_SUPPORTED')} disabled={!isFirefox} className='w-60'>
+            <div>
+                <Button
+                    variant='secondaryBlack'
+                    className='!h-fit !w-fit !px-3 !py-1.5 !text-sm !font-medium'
+                    iconTrailing='qr-code'
+                    iconClass='h-4 w-4'
+                    onClick={onClick} 
+                    disabled={isFirefox}
+                >
+                    {t('PAGES.SEND.QR_MODAL.UPLOAD_QR')}
+                </Button>
+            </div> 
+        </Tooltip>
     );
 };
 

--- a/src/i18n/ns/pages.ts
+++ b/src/i18n/ns/pages.ts
@@ -276,7 +276,7 @@ export default {
             UPLOAD_QR: 'Upload QR',
             CHOOSE_YOUR_QR_CODE: 'Choose your QR Code, and the fields will auto-populate',
             PROCESSING_IMAGE: "We're processing your image...",
-            FIREFOX_NOT_SUPPORTED: "QR Code upload is only supported on Chromium based browsers",
+            FIREFOX_NOT_SUPPORTED: 'QR Code upload is only supported on Chromium based browsers',
         },
     },
     ADDRESS_SETTINGS: {

--- a/src/i18n/ns/pages.ts
+++ b/src/i18n/ns/pages.ts
@@ -276,6 +276,7 @@ export default {
             UPLOAD_QR: 'Upload QR',
             CHOOSE_YOUR_QR_CODE: 'Choose your QR Code, and the fields will auto-populate',
             PROCESSING_IMAGE: "We're processing your image...",
+            FIREFOX_NOT_SUPPORTED: "QR Code upload is only supported on Chromium based browsers",
         },
     },
     ADDRESS_SETTINGS: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[QR Code] Disable Upload QR button on Firefox](https://app.clickup.com/t/86du5kc0b)

## Summary

- QR Upload button is now disabled on Firefox.
- A new tooltip will be displayed when hovering this disabled button.

<img width="373" alt="image" src="https://github.com/user-attachments/assets/7e72e161-287f-4bfb-b17c-6a5667549780">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
