### PR TITLE
fix: progress bar transtion on firefox

### DIFF
--- a/src/shared/components/progress/ProgressBar.tsx
+++ b/src/shared/components/progress/ProgressBar.tsx
@@ -26,8 +26,8 @@ export const ProgressBar = ({
                     className={cn(
                         'h-full rounded-3xl bg-theme-primary-700 dark:bg-theme-primary-650',
                         {
-                            'w-full': isFilled && shouldAnimate || index < activeIndex,
-                            'w-0': !isFilled || isFilled && !shouldAnimate,
+                            'w-full': (isFilled && shouldAnimate) || index < activeIndex,
+                            'w-0': !isFilled || (isFilled && !shouldAnimate),
                             'animate-fillProgress': shouldAnimate,
                         },
                     )}

--- a/src/shared/components/progress/ProgressBar.tsx
+++ b/src/shared/components/progress/ProgressBar.tsx
@@ -26,8 +26,8 @@ export const ProgressBar = ({
                     className={cn(
                         'h-full rounded-3xl bg-theme-primary-700 dark:bg-theme-primary-650',
                         {
-                            'w-full': isFilled,
-                            'w-0': !isFilled,
+                            'w-full': isFilled && shouldAnimate || index < activeIndex,
+                            'w-0': !isFilled || isFilled && !shouldAnimate,
                             'animate-fillProgress': shouldAnimate,
                         },
                     )}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -83,7 +83,7 @@ export default {
                     'fadeInAndTransform 0.8s ease-in-out forwards, scale 0.4s ease-in-out 1s forwards',
                 translateUp: 'translateUp 0.5s ease-in-out 2s forwards',
                 decreaseHeight: 'decreaseHeight 0.5s ease-in-out 2s forwards',
-                fillProgress: 'fillProgressBar 5s ease-in-out',
+                fillProgress: 'fillProgressBar 5s ease-in-out forwards',
             },
             zIndex: {
                 1: '1',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[Firefox] Visual issue with Carousel on Firefox](https://app.clickup.com/t/86du5k6qb)

## Summary

- Progress bar from Onboarding page will now transition correctly on Firefox.


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

https://github.com/user-attachments/assets/e45564c7-3c62-450d-a3e9-156d9930b481



## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
