### PR TITLE
fix: resolve issue where extension would not load on sites

### DIFF
--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -24,7 +24,7 @@
     ],
     "content_scripts": [
         {
-            "matches": ["https://*/*"],
+            "matches": ["https://*/*", "http://*/*"],
             "js": ["src/content.ts"],
             "run_at": "document_start"
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Odd issue, but the extension stopped working on sites like https://demo.arkconnect.io/ and https://live.arkscan.io/ with the release of chrome v130, throwing in error in devtools regarding Content Security Policy and it not wanting to load the `content.js` file. After a lot of configuration adjustments it seems to work with this small change where the `content_scripts` gets changed from purely https to both https and http. 

Note that it only works when both are included. Having either https or http in itself will not allow the extension to work, but when the array contains both is magically works. The Firefox manifest remains as-is as it works fine there with just the https content scripts entry.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
