### PR TITLE
fix: truncate address

### DIFF
--- a/src/components/wallet/AddressSettings.tsx
+++ b/src/components/wallet/AddressSettings.tsx
@@ -172,7 +172,9 @@ const AddressRow = ({ address }: { address: Contracts.IReadWriteWallet }) => {
                     {address.isLedger() && <LedgerIcon />}
                 </div>
 
-                <p className='typeset-body text-light-black dark:text-white'>{address.address()}</p>
+                <p className='typeset-body text-light-black dark:text-white'>
+                    {trimAddress(address.address(), 'longest')}
+                </p>
 
                 <p className='typeset-body cursor-pointer font-bold text-light-black dark:text-white'>
                     <Amount

--- a/src/components/wallet/import/ImportedWallet.tsx
+++ b/src/components/wallet/import/ImportedWallet.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ImportedWalletFormik } from '.';
 import { Contracts } from '@/lib/profiles';
 import { Button, Heading, HeadingDescription, Input } from '@/shared/components';
+import trimAddress from '@/lib/utils/trimAddress';
 
 type Props = {
     goToNextStep: () => void;
@@ -53,7 +54,7 @@ const ImportedWallet = ({ goToNextStep, formik }: Props) => {
                         {t('COMMON.ADDRESS')}
                     </p>
                     <p className='typeset-headline text-light-black dark:text-white'>
-                        {formik.values.wallet?.address()}
+                        {trimAddress(formik.values.wallet?.address()!, 'longest')}
                     </p>
                 </div>
 

--- a/src/components/wallet/import/ImportedWallet.tsx
+++ b/src/components/wallet/import/ImportedWallet.tsx
@@ -54,7 +54,7 @@ const ImportedWallet = ({ goToNextStep, formik }: Props) => {
                         {t('COMMON.ADDRESS')}
                     </p>
                     <p className='typeset-headline text-light-black dark:text-white'>
-                        {trimAddress(formik.values.wallet?.address()!, 'longest')}
+                        {trimAddress(formik.values.wallet?.address() as string, 'longest')}
                     </p>
                 </div>
 

--- a/src/lib/utils/trimAddress.test.ts
+++ b/src/lib/utils/trimAddress.test.ts
@@ -11,7 +11,9 @@ describe('trimAddress', () => {
     it('uses 24 characters with long trim', async () => {
         expect(trimAddress('1', 'long')).toBe('1');
         expect(trimAddress('1234567890123456', 'long')).toBe('1234567890123456');
-        expect(trimAddress('1234567890123456789123456789', 'long')).toBe('123456789012…789123456789');
+        expect(trimAddress('1234567890123456789123456789', 'long')).toBe(
+            '123456789012…789123456789',
+        );
     });
 
     it('uses 34 characters with longest trim', async () => {

--- a/src/lib/utils/trimAddress.test.ts
+++ b/src/lib/utils/trimAddress.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from 'vitest';
 import trimAddress from './trimAddress';
 
 describe('trimAddress', () => {
-    it('uses 8 characters with short trim', async () => {
+    it('uses 13 characters with short trim', async () => {
         expect(trimAddress('1', 'short')).toBe('1');
         expect(trimAddress('12345678', 'short')).toBe('12345678');
-        expect(trimAddress('123456789', 'short')).toBe('1234…6789');
+        expect(trimAddress('123456789123456', 'short')).toBe('123456…123456');
     });
 
-    it('uses 16 characters with long trim', async () => {
+    it('uses 24 characters with long trim', async () => {
         expect(trimAddress('1', 'long')).toBe('1');
         expect(trimAddress('1234567890123456', 'long')).toBe('1234567890123456');
-        expect(trimAddress('12345678901234567', 'long')).toBe('12345678…01234567');
+        expect(trimAddress('1234567890123456789123456789', 'long')).toBe('123456789012…789123456789');
     });
 
-    it('uses 24 characters with longest trim', async () => {
+    it('uses 34 characters with longest trim', async () => {
         expect(trimAddress('1', 'longest')).toBe('1');
         expect(trimAddress('123456789012345678912345', 'longest')).toBe('123456789012345678912345');
-        expect(trimAddress('1234567890123456789123456', 'longest')).toBe(
-            '123456789012…456789123456',
+        expect(trimAddress('123456789012345678912345689123456789', 'longest')).toBe(
+            '12345678901234567…12345689123456789',
         );
     });
 

--- a/src/lib/utils/trimAddress.ts
+++ b/src/lib/utils/trimAddress.ts
@@ -6,9 +6,9 @@ const trimAddress = (
         typeof modeOrLength === 'number'
             ? modeOrLength
             : {
-                  short: 8,
-                  long: 16,
-                  longest: 24,
+                  short: 13,
+                  long: 24,
+                  longest: 34,
               }[modeOrLength];
 
     if (address.length <= maxLength) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dx65cdb

This PR fixes address truncation in various pages.

Address settings page:
![image](https://github.com/user-attachments/assets/f48056ad-4c15-4b0f-b81f-91677efed4c1)

Import address success page:
![image](https://github.com/user-attachments/assets/4e471683-d87b-4805-bc41-20728776fc7b)



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
