### PR TITLE
fix: hide validator username when not set

### DIFF
--- a/src/components/approve/ActionBody.tsx
+++ b/src/components/approve/ActionBody.tsx
@@ -61,7 +61,6 @@ export const ActionBody = ({
     convertedTotalAmount,
     hasHigherCustomFee = null,
     hasLowerCustomFee = null,
-    memo = null,
 }: ActionBodyProps) => {
     const { t } = useTranslation();
 
@@ -129,15 +128,6 @@ export const ActionBody = ({
                 />
             )}
 
-            {memo && (
-                <ActionBodyRow
-                    label={t('COMMON.MEMO')}
-                    value={memo}
-                    className='truncate pl-20'
-                    tooltipContent={memo}
-                />
-            )}
-
             {unvote?.name && (
                 <ActionBodyRow label={t('COMMON.UNVOTE_VALIDATOR_NAME')} value={unvote.name} />
             )}
@@ -165,7 +155,7 @@ export const ActionBody = ({
                 />
             )}
 
-            {vote?.address && (
+            {vote?.name && (
                 <ActionBodyRow label={t('COMMON.VOTE_VALIDATOR_NAME')} value={vote.name} />
             )}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dx5y4v8


![image](https://github.com/user-attachments/assets/f21e1ddc-50aa-400f-910d-8be0b1873aea)
![image](https://github.com/user-attachments/assets/0979e7bd-1d75-4abe-b3c7-c3541ba95ddc)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
