### PR TITLE
refactor: enable private key viewing

### DIFF
--- a/src/components/settings/general/ViewSensitiveInfo.tsx
+++ b/src/components/settings/general/ViewSensitiveInfo.tsx
@@ -3,6 +3,7 @@ import { boolean, object, string } from 'yup';
 import { useFormik } from 'formik';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PrivateKey } from '@arkecosystem/typescript-crypto';
 import YourPrivateKey from './YourPrivateKey';
 import SubPageLayout from '@/components/settings/SubPageLayout';
 import { Button, Checkbox, HeadingDescription, PasswordInput } from '@/shared/components';
@@ -10,7 +11,6 @@ import { useErrorHandlerContext } from '@/lib/context/ErrorHandler';
 import { useProfileContext } from '@/lib/context/Profile';
 import YourPassphrase from '@/components/settings/general/YourPassphrase';
 import { Footer } from '@/shared/components/layout/Footer';
-import { PrivateKey } from '@arkecosystem/typescript-crypto';
 
 type SensitiveInfoFormik = {
     password: string;

--- a/src/components/settings/general/ViewSensitiveInfo.tsx
+++ b/src/components/settings/general/ViewSensitiveInfo.tsx
@@ -10,6 +10,7 @@ import { useErrorHandlerContext } from '@/lib/context/ErrorHandler';
 import { useProfileContext } from '@/lib/context/Profile';
 import YourPassphrase from '@/components/settings/general/YourPassphrase';
 import { Footer } from '@/shared/components/layout/Footer';
+import { PrivateKey } from '@arkecosystem/typescript-crypto';
 
 type SensitiveInfoFormik = {
     password: string;
@@ -64,12 +65,9 @@ const ViewSensitiveInfo = () => {
                         mnemonic,
                     });
 
-                    // TODO fix
-                    // const privateKeyDto = await wallet
-                    //     .privateKeyService()
-                    //     .fromMnemonic(mnemonic, { bip39: true });
+                    const privateKeyDto = PrivateKey.fromPassphrase(mnemonic);
 
-                    setPrivateKey('private-key');
+                    setPrivateKey(privateKeyDto.privateKey);
                     setPassphrase(mnemonic);
                 } catch (error) {
                     formikHelpers.setFieldError('password', t('MISC.INCORRECT_PASSWORD'));


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dx35z4t

This PR enable Private Key viewing

[Screencast from 2025-07-07 15-43-28.webm](https://github.com/user-attachments/assets/b5f77eb1-e226-4abf-b338-31dfb12db0be)



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
