### PR TITLE
chore: remove wallet sync for message signing

### DIFF
--- a/src/lib/background/extension.wallet.ts
+++ b/src/lib/background/extension.wallet.ts
@@ -110,8 +110,6 @@ export function Wallet({ wallet }: { wallet: Contracts.IReadWriteWallet }) {
          * @returns {Promise<SignedMessage>}
          */
         async signMessage(message: string): Promise<SignedMessage> {
-            // await wallet.synchroniser().coin();
-
             const mnemonic = await wallet.confirmKey().get(wallet.profile().password().get());
 
             return await wallet.message().sign({


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dx35zb1

While doing PSDK migration I disabled `wallet.synchroniser().coin()` calls, goal of this PR is to make sure disabled calls are either enabled or removed as needed. I fixed and enabled calls (`wallet.network().sync()`) for transaction sending methods in previous PRs, but for signing it is not really needed.

https://github.com/ArdentHQ/arkconnect-extension/pull/456/files#diff-6a983d1a387705c303bb6557e189e37def7faa616aac303cdce793456976ca38R64

**Testing:**
- Load extension
- Load demo
- Try to sign a message

[Screencast from 2025-07-07 16-43-29.webm](https://github.com/user-attachments/assets/f3dd0f08-59af-4e77-8c27-e07268972780)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
