### PR TITLE
chore: dev seeder fallback for non-bip39 passphrases

### DIFF
--- a/src/dev/utils/dev.ts
+++ b/src/dev/utils/dev.ts
@@ -56,9 +56,7 @@ export const createTestProfile = async ({ env }: { env: Environment }): Promise<
         try {
             wallet = await profile.walletFactory().fromMnemonicWithBIP39(fixtureWallet);
         } catch {
-            wallet = await profile
-                .walletFactory()
-                .fromSecret({ secret: fixtureWallet.mnemonic });
+            wallet = await profile.walletFactory().fromSecret({ secret: fixtureWallet.mnemonic });
         }
 
         wallet.mutator().alias(getDefaultAlias({ profile, network: wallet.network() }));

--- a/src/dev/utils/dev.ts
+++ b/src/dev/utils/dev.ts
@@ -52,7 +52,14 @@ export const createTestProfile = async ({ env }: { env: Environment }): Promise<
     const walletFixtures = getTestingAddresses();
 
     for (const fixtureWallet of walletFixtures) {
-        const wallet = await profile.walletFactory().fromMnemonicWithBIP39(fixtureWallet);
+        let wallet;
+        try {
+            wallet = await profile.walletFactory().fromMnemonicWithBIP39(fixtureWallet);
+        } catch {
+            wallet = await profile
+                .walletFactory()
+                .fromSecret({ secret: fixtureWallet.mnemonic });
+        }
 
         wallet.mutator().alias(getDefaultAlias({ profile, network: wallet.network() }));
 


### PR DESCRIPTION
## Checklist

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [x] I checked my (code) changes for obvious issues, debug statements and commented code
- [x] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] Ready to be merged