### PR TITLE
fix: transaction confirmed explorer url

### DIFF
--- a/src/pages/TransactionApproved.tsx
+++ b/src/pages/TransactionApproved.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { BigNumber } from '../lib/helpers';
 import { useEnvironmentContext } from '@/lib/context/Environment';
 import { useProfileContext } from '@/lib/context/Profile';
 import formatDomain from '@/lib/utils/formatDomain';
@@ -13,21 +12,18 @@ import getActiveCoin from '@/lib/utils/getActiveCoin';
 import { useConfirmedTransaction } from '@/lib/hooks/useConfirmedTransaction';
 import { ApproveLayout } from '@/components/approve/ApproveLayout';
 import { Footer } from '@/shared/components/layout/Footer';
-import { ExtendedConfirmedTransactionData } from '@/lib/profiles/transaction.dto';
+import { BigNumber } from '../lib/helpers';
 
 const TransactionFooter = ({
     onClose,
     isTransactionConfirmed,
-    state,
+    explorerLink,
 }: {
     isTransactionConfirmed: boolean;
-    state: any;
     onClose: () => void;
+    explorerLink: string;
 }) => {
     const { t } = useTranslation();
-    const { transaction } = state;
-
-    const explorerLink = (transaction as ExtendedConfirmedTransactionData).explorerLink();
 
     return (
         <Footer className='flex flex-col gap-5'>
@@ -74,6 +70,7 @@ const TransactionApproved = () => {
 
     const transactionId = state?.transaction.id;
     const wallet = profile.wallets().findById(state?.walletId);
+    const explorerLink = wallet.link().transaction(transactionId);
 
     const isTransactionConfirmed = useConfirmedTransaction({ wallet, transactionId });
 
@@ -93,7 +90,7 @@ const TransactionApproved = () => {
                 <TransactionFooter
                     onClose={onClose}
                     isTransactionConfirmed={isTransactionConfirmed}
-                    state={state}
+                    explorerLink={explorerLink}
                 />
             }
         >

--- a/src/pages/TransactionApproved.tsx
+++ b/src/pages/TransactionApproved.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { BigNumber } from '../lib/helpers';
 import { useEnvironmentContext } from '@/lib/context/Environment';
 import { useProfileContext } from '@/lib/context/Profile';
 import formatDomain from '@/lib/utils/formatDomain';
@@ -12,7 +13,6 @@ import getActiveCoin from '@/lib/utils/getActiveCoin';
 import { useConfirmedTransaction } from '@/lib/hooks/useConfirmedTransaction';
 import { ApproveLayout } from '@/components/approve/ApproveLayout';
 import { Footer } from '@/shared/components/layout/Footer';
-import { BigNumber } from '../lib/helpers';
 
 const TransactionFooter = ({
     onClose,

--- a/src/pages/VoteApproved.tsx
+++ b/src/pages/VoteApproved.tsx
@@ -2,6 +2,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useEffect } from 'react';
 import { runtime } from 'webextension-polyfill';
+import { BigNumber } from '../lib/helpers';
+import { ApproveActionType } from './Approve';
 import removeWindowInstance from '@/lib/utils/removeWindowInstance';
 import { Button, ExternalLink, Heading, Icon, Loader } from '@/shared/components';
 import formatDomain from '@/lib/utils/formatDomain';
@@ -12,8 +14,6 @@ import getActiveCoin from '@/lib/utils/getActiveCoin';
 import { useConfirmedTransaction } from '@/lib/hooks/useConfirmedTransaction';
 import { ApproveLayout } from '@/components/approve/ApproveLayout';
 import { Footer } from '@/shared/components/layout/Footer';
-import { BigNumber } from '../lib/helpers';
-import { ApproveActionType } from './Approve';
 
 const VoteApprovedFooter = ({
     onClose,

--- a/src/pages/VoteApproved.tsx
+++ b/src/pages/VoteApproved.tsx
@@ -2,9 +2,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useEffect } from 'react';
 import { runtime } from 'webextension-polyfill';
-import { BigNumber } from '../lib/helpers';
-import { ExtendedConfirmedTransactionData } from '../lib/profiles/transaction.dto';
-import { ApproveActionType } from './Approve';
 import removeWindowInstance from '@/lib/utils/removeWindowInstance';
 import { Button, ExternalLink, Heading, Icon, Loader } from '@/shared/components';
 import formatDomain from '@/lib/utils/formatDomain';
@@ -15,21 +12,19 @@ import getActiveCoin from '@/lib/utils/getActiveCoin';
 import { useConfirmedTransaction } from '@/lib/hooks/useConfirmedTransaction';
 import { ApproveLayout } from '@/components/approve/ApproveLayout';
 import { Footer } from '@/shared/components/layout/Footer';
+import { BigNumber } from '../lib/helpers';
+import { ApproveActionType } from './Approve';
 
 const VoteApprovedFooter = ({
     onClose,
     isTransactionConfirmed,
-    state,
+    explorerLink,
 }: {
     onClose: () => void;
     isTransactionConfirmed: boolean;
-    state: any;
+    explorerLink: string;
 }) => {
     const { t } = useTranslation();
-
-    const { vote } = state;
-
-    const explorerLink = (vote as ExtendedConfirmedTransactionData).explorerLink();
 
     return (
         <Footer className='flex w-full flex-col gap-5'>
@@ -70,6 +65,7 @@ const VoteApproved = () => {
     const { session, vote } = state;
 
     const wallet = profile.wallets().findById(session.walletId);
+    const explorerLink = wallet.link().transaction(vote.id);
 
     const showFiat = state.walletNetwork === WalletNetwork.MAINNET;
 
@@ -109,7 +105,7 @@ const VoteApproved = () => {
                 <VoteApprovedFooter
                     onClose={onClose}
                     isTransactionConfirmed={isTransactionConfirmed}
-                    state={state}
+                    explorerLink={explorerLink}
                 />
             }
         >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

related to https://app.clickup.com/t/86e1f5fj1

i noticed this during testing of another change - PR #505 changed the explorer links to be consistent but the handling I implemented was wrong for the Confirmation screen for sent transactions. 

The issue itself was a blank screen when approving a transaction.

I'm not sure how it was missed in the previous PR as I'm sure I tested it for both transfers and votes. Perhaps the previous functionality worked for a certain scenario where not just an object was returned from the state, but an ExtendedConfirmedTransactionData class, which is where the `explorerLink` method resides?

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
