### PR TITLE
chore: install ardenthq/ai conventions

### DIFF
--- a/.claude/ardenthq/core.md
+++ b/.claude/ardenthq/core.md
@@ -1,4 +1,4 @@
-<!-- airc v0.1.0 — managed file, do not edit -->
+<!-- airc v0.2.0 — managed file, do not edit -->
 <!-- Local override: CLAUDE.local.md. Per-repo override: below the @imports in CLAUDE.md. Permanent override: PR to https://github.com/ardenthq/airc -->
 
 # Baseline
@@ -19,6 +19,7 @@ Shared rules for every repo. Apply to any stack.
 
 - Always draft (`gh pr create --draft`)
 - Base branch: the repo's default
+- If the repo has a `.github/PULL_REQUEST_TEMPLATE.md`, fill it in as the PR body and check off the items that apply. `gh pr create` ignores the template unless you pass it yourself — write the filled body to a file and use `--body-file`
 - **Never** reference Claude / AI / agents in title, body, branch name, or comments
 
 ## Pre-push checks
@@ -57,13 +58,6 @@ Exact commands are repo-defined (see the repo's `CLAUDE.md` / `composer.json` / 
 - Concise. Skip the obvious.
 - End-of-turn summary: one or two sentences — what changed, what's next.
 - No long essays, no unnecessary disclaimers, no "sure, happy to help…"
-
-## Recommended dev setup (one-time per dev)
-
-Not required, but recommended to improve the Claude experience. The CLI detects whether they're already installed and prints recommendations only for missing ones.
-
-- **caveman** — compresses Claude's output (~65% token savings):
-  `curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.sh | bash`
 
 ## Overrides
 

--- a/.claude/ardenthq/core.md
+++ b/.claude/ardenthq/core.md
@@ -1,0 +1,72 @@
+<!-- airc v0.1.0 — managed file, do not edit -->
+<!-- Local override: CLAUDE.local.md. Per-repo override: below the @imports in CLAUDE.md. Permanent override: PR to https://github.com/ardenthq/airc -->
+
+# Baseline
+
+Shared rules for every repo. Apply to any stack.
+
+## Commits
+
+- Format: [Conventional Commits](https://www.conventionalcommits.org) — `feat:`, `fix:`, `chore:`, `style:`, `refactor:`, `test:`, `docs:`
+- Subject line only, ideally under 50 characters
+- Human, direct tone. Avoid formal or robotic voice ("this commit introduces…", "this change implements…")
+- **Never** add `Co-Authored-By` or any mention of Claude / AI / agents
+- **Never** add a description or body — subject only
+- Commit incrementally when a logical chunk lands — don't batch everything at the end
+- Examples: `feat: scaffold composer package`, `fix: stack detection for inertia`
+
+## Pull Requests
+
+- Always draft (`gh pr create --draft`)
+- Base branch: the repo's default
+- **Never** reference Claude / AI / agents in title, body, branch name, or comments
+
+## Pre-push checks
+
+Standard order before pushing:
+
+1. Formatter → 2. Linter → 3. Static analysis → 4. Tests
+
+Exact commands are repo-defined (see the repo's `CLAUDE.md` / `composer.json` / `package.json`). If the formatter modifies files, commit those changes before pushing so CI doesn't kick back automated `style:` cleanup commits.
+
+**Mid-task (recommendation):** for long tasks, run only affected/new checks during the work; defer the full suite to the end. For short tasks, skip intermediate runs. Don't run checks repeatedly mid-work — once at completion is usually enough.
+
+## Security
+
+- Never commit `.env`, credentials, tokens, or any secret
+- Flag any new dependency as suspect before adding it (typosquatting, unknown maintainer, etc.)
+- No destructive operations (`force-push`, branch deletion, history rewrite, `git reset --hard`, `rm -rf`) without explicit confirmation from the dev
+- For external tools (CI, pastebins, gists): consider whether uploaded content could be sensitive — it may be cached or indexed even if later deleted
+
+## Code style
+
+- Follow existing patterns before introducing new ones
+- Reuse existing components/helpers before writing new ones
+- No comments unless explaining a non-obvious **why** (a hidden constraint, a subtle invariant, a workaround for a specific bug)
+- Well-named identifiers > a comment explaining the "what"
+- **Don't document changes in comments.** Comments describe the code as it is, not how it got there:
+  - ❌ `// moved from backend to frontend`
+  - ❌ `// renamed from foo to bar`
+  - ❌ `// replaces the previous logic that used X`
+  - ❌ `// added for issue #123`
+  - ✅ omit the comment — git log / PR tells the story
+- Don't reference callers or temporal context: no `// used by X`, `// for the Y flow`, `// added in sprint Z`
+
+## Claude reply style
+
+- Concise. Skip the obvious.
+- End-of-turn summary: one or two sentences — what changed, what's next.
+- No long essays, no unnecessary disclaimers, no "sure, happy to help…"
+
+## Recommended dev setup (one-time per dev)
+
+Not required, but recommended to improve the Claude experience. The CLI detects whether they're already installed and prints recommendations only for missing ones.
+
+- **caveman** — compresses Claude's output (~65% token savings):
+  `curl -fsSL https://raw.githubusercontent.com/JuliusBrussee/caveman/main/install.sh | bash`
+
+## Overrides
+
+- Personal override: create `CLAUDE.local.md` (gitignored)
+- Per-repo override: add rules below the `@imports` in this repo's `CLAUDE.md`
+- Permanent shared override: PR against the upstream guidelines repo

--- a/.claude/ardenthq/js.md
+++ b/.claude/ardenthq/js.md
@@ -1,4 +1,4 @@
-<!-- airc v0.1.0 — managed file, do not edit -->
+<!-- airc v0.2.0 — managed file, do not edit -->
 
 # JavaScript / TypeScript
 
@@ -15,6 +15,7 @@ Code-writing rules for JS/TS files. Apply when writing or editing JS/TS code.
 ## Syntax
 
 - Named exports over default exports (except where a framework requires default, e.g. a Next.js page).
+- Use curly braces for every control structure, even single-line bodies.
 
 ## Comments
 

--- a/.claude/ardenthq/js.md
+++ b/.claude/ardenthq/js.md
@@ -1,0 +1,38 @@
+<!-- airc v0.1.0 — managed file, do not edit -->
+
+# JavaScript / TypeScript
+
+Code-writing rules for JS/TS files. Apply when writing or editing JS/TS code.
+
+## Types
+
+- TypeScript in strict mode. Don't disable strict checks per file.
+- Avoid `any` — use `unknown` and narrow, or a precise type.
+- Add explicit return types to exported functions.
+- Prefer `type` aliases; use `interface` only when you need declaration merging.
+- Keep shared/exported types in a dedicated `*.types.ts` file, not scattered across unrelated modules.
+
+## Syntax
+
+- Named exports over default exports (except where a framework requires default, e.g. a Next.js page).
+
+## Comments
+
+- No comments unless explaining a non-obvious **why** (see `core.md`).
+- Well-named identifiers over a comment explaining the "what".
+
+## Package manager
+
+- Prefer **pnpm** over `npm` or `yarn`.
+
+## Scripts
+
+Use the standard scripts; don't invoke the underlying tool directly:
+
+- `pnpm format` — formatter (Prettier)
+- `pnpm lint` — linter (ESLint)
+- `pnpm test` / `pnpm test:coverage` — tests
+
+## Avoid
+
+- Mutating arguments or inputs — take them immutable, return new values.

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ build.zip
 # WXT
 .wxt
 web-ext.config.ts
+
+# airc
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+@.claude/ardenthq/core.md
+@.claude/ardenthq/js.md
+
+<!-- Project-specific instructions go below. -->

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "1.13.1",
     "type": "module",
     "scripts": {
-        "postinstall": "wxt prepare",
+        "postinstall": "wxt prepare && npx @ardenthq/airc update",
         "dev": "VITE_SEED_ADDRESSES=true wxt",
         "dev:firefox": "VITE_SEED_ADDRESSES=true wxt -b firefox",
         "dev:bare": "wxt",


### PR DESCRIPTION
Adds the shared `@ardenthq/airc` conventions to arkconnect-extension.

`npx @ardenthq/airc install` creates `CLAUDE.md` with the `@import` lines, drops the guidelines into `.claude/ardenthq/`, and ignores `CLAUDE.local.md`. It's a JS/TS repo, so it picks up `core` + `js`. The `postinstall` hook keeps the managed files in sync on every `pnpm install`.

No tooling recommendations show up here — prettier and eslint are already installed, so the CLI correctly skips them (a good check that the detection works on a real repo).

Output:

```
✓ ardenthq-ai
  wrote core.md, js.md
  created CLAUDE.md with imports
  added CLAUDE.local.md to .gitignore
```

> ⚠️ Depends on releasing [`@ardenthq/airc`](https://github.com/ArdentHQ/airc) to npm — until then `npx @ardenthq/ai` won't resolve.

