### PR TITLE
refactor: use side panel when connecting with webapp

### DIFF
--- a/src/OneTimeEventHandlers.ts
+++ b/src/OneTimeEventHandlers.ts
@@ -9,7 +9,10 @@ import { SessionEntries } from '@/lib/store/session';
 import { VoteInput } from '@/lib/mainsail/transaction.contract';
 import { setLocalValue } from '@/lib/utils/localStorage';
 import { applySidepanelMode, closeSidepanel, openPopupForWindow } from '@/lib/background/sidepanel';
-import { executePendingSidepanelCallback, setSidepanelEnabled } from '@/lib/background/eventListenerHandlers';
+import {
+    executePendingSidepanelCallback,
+    setSidepanelEnabled,
+} from '@/lib/background/eventListenerHandlers';
 
 export enum OneTimeEvents {
     SEND_VOTE = 'SEND_VOTE',

--- a/src/OneTimeEventHandlers.ts
+++ b/src/OneTimeEventHandlers.ts
@@ -8,7 +8,8 @@ import { SendTransferInput } from '@/lib/background/extension.wallet';
 import { SessionEntries } from '@/lib/store/session';
 import { VoteInput } from '@/lib/mainsail/transaction.contract';
 import { setLocalValue } from '@/lib/utils/localStorage';
-import { applySidepanelMode, openPopupForWindow } from '@/lib/background/sidepanel';
+import { applySidepanelMode, closeSidepanel, openPopupForWindow } from '@/lib/background/sidepanel';
+import { executePendingSidepanelCallback, setSidepanelEnabled } from '@/lib/background/eventListenerHandlers';
 
 export enum OneTimeEvents {
     SEND_VOTE = 'SEND_VOTE',
@@ -34,6 +35,8 @@ export enum OneTimeEvents {
     SET_LAST_SCREEN = 'SET_LAST_SCREEN',
     CLEAR_LAST_SCREEN = 'CLEAR_LAST_SCREEN',
     SET_OPEN_IN_SIDEPANEL = 'SET_OPEN_IN_SIDEPANEL',
+    SIDEPANEL_READY = 'SIDEPANEL_READY',
+    CLOSE_SIDEPANEL = 'CLOSE_SIDEPANEL',
 }
 
 export function OneTimeEventHandlers(extension: ReturnType<typeof Extension>) {
@@ -161,6 +164,7 @@ export function OneTimeEventHandlers(extension: ReturnType<typeof Extension>) {
         [OneTimeEvents.SET_OPEN_IN_SIDEPANEL]: async (request: any) => {
             const enabled = request.data.enabled as boolean;
             const windowId = request.data.windowId as number | undefined;
+            setSidepanelEnabled(enabled);
             await setLocalValue('openInSidepanel', enabled);
             await applySidepanelMode(enabled);
             if (!enabled && windowId !== undefined) {
@@ -250,6 +254,15 @@ export function OneTimeEventHandlers(extension: ReturnType<typeof Extension>) {
             extension.profile().settings().forget(ProfileData.LastVisitedPage);
             await extension.persist();
             return;
+        },
+
+        [OneTimeEvents.SIDEPANEL_READY]: async (request: any) => {
+            executePendingSidepanelCallback(request.data?.wasAlreadyOpen ?? false);
+        },
+
+        [OneTimeEvents.CLOSE_SIDEPANEL]: async (request: any) => {
+            const windowId = request.data.windowId as number;
+            await closeSidepanel(windowId);
         },
     };
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -3,7 +3,10 @@ import { UUID } from '@ardenthq/arkvault-crypto';
 import { AutoLockTimer, getLocalValues, setLocalValue } from './lib/utils/localStorage';
 import { Extension } from './lib/background/extension';
 import keepServiceWorkerAlive from './lib/background/keepServiceWorkerAlive';
-import { longLivedConnectionHandlers, setSidepanelEnabled } from './lib/background/eventListenerHandlers';
+import {
+    longLivedConnectionHandlers,
+    setSidepanelEnabled,
+} from './lib/background/eventListenerHandlers';
 import { OneTimeEventHandlers, OneTimeEvents } from '@/OneTimeEventHandlers';
 import { applySidepanelMode } from '@/lib/background/sidepanel';
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -3,7 +3,7 @@ import { UUID } from '@ardenthq/arkvault-crypto';
 import { AutoLockTimer, getLocalValues, setLocalValue } from './lib/utils/localStorage';
 import { Extension } from './lib/background/extension';
 import keepServiceWorkerAlive from './lib/background/keepServiceWorkerAlive';
-import { longLivedConnectionHandlers } from './lib/background/eventListenerHandlers';
+import { longLivedConnectionHandlers, setSidepanelEnabled } from './lib/background/eventListenerHandlers';
 import { OneTimeEventHandlers, OneTimeEvents } from '@/OneTimeEventHandlers';
 import { applySidepanelMode } from '@/lib/background/sidepanel';
 
@@ -47,6 +47,7 @@ const handleLongLivedConnection = async (message: any, port: Runtime.Port) => {
                 data: {
                     ...message.data,
                     tabId: port.sender?.tab?.id,
+                    windowId: port.sender?.tab?.windowId,
                     port: port,
                 },
             },
@@ -64,8 +65,12 @@ runtime.onInstalled.addListener(async (details) => {
     }
 });
 
-// Restore sidepanel state after service worker restarts
-void getLocalValues().then(({ openInSidepanel }) => applySidepanelMode(openInSidepanel ?? false));
+// Restore sidepanel state after service worker restarts and seed the in-memory cache
+void getLocalValues().then(({ openInSidepanel }) => {
+    const enabled = openInSidepanel ?? false;
+    setSidepanelEnabled(enabled);
+    applySidepanelMode(enabled);
+});
 
 initOneTimeEventListeners();
 keepServiceWorkerAlive();

--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -1,6 +1,9 @@
 import { init } from '@sentry/react';
 import { createRoot } from 'react-dom/client';
+import { windows } from 'webextension-polyfill';
 import App, { MainWrapper } from '@/App';
+import { getLocalValues } from '@/lib/utils/localStorage';
+import { openSidepanel } from '@/lib/background/sidepanel';
 import '@/main.css';
 
 if (import.meta.env.VITE_SENTRY_DSN) {
@@ -10,8 +13,24 @@ if (import.meta.env.VITE_SENTRY_DSN) {
     });
 }
 
-createRoot(document.getElementById('extension-root')!).render(
-    <MainWrapper>
-        <App />
-    </MainWrapper>,
-);
+// When sidepanel mode is enabled and the popup is opened directly (e.g. from a
+// dapp button that links straight to popup.html), redirect to the sidepanel
+// instead. Extension popup pages retain user gesture context across awaits so
+// openSidepanel() works here even after the storage read.
+void (async () => {
+    const { openInSidepanel } = await getLocalValues();
+    if (openInSidepanel) {
+        const win = await windows.getCurrent();
+        if (win.id !== undefined) {
+            await openSidepanel(win.id);
+        }
+        window.close();
+        return;
+    }
+
+    createRoot(document.getElementById('extension-root')!).render(
+        <MainWrapper>
+            <App />
+        </MainWrapper>,
+    );
+})();

--- a/src/lib/background/eventListenerHandlers.ts
+++ b/src/lib/background/eventListenerHandlers.ts
@@ -11,6 +11,7 @@ import {
 import constants from '@/constants';
 import { Contracts } from '@/lib/profiles';
 import { WalletNetwork } from '@/lib/store/wallet';
+import { openSidepanel } from '@/lib/background/sidepanel';
 
 export type EventPayload<T> = {
     type: keyof typeof longLivedConnectionHandlers;
@@ -50,10 +51,52 @@ export type SignVoteData = {
 
 let extensionWindowId: number | null = null;
 
-const createExtensionWindow = async (onWindowReady: (id?: number) => void) => {
+let pendingSidepanelCallback: ((id?: number, sidepanelWasOpen?: boolean) => void) | null = null;
+
+// Cached in memory so createExtensionWindow can check without an await,
+// keeping the user-gesture context alive for chrome.sidePanel.open().
+let sidepanelEnabled = false;
+
+export const setSidepanelEnabled = (enabled: boolean): void => {
+    sidepanelEnabled = enabled;
+};
+
+export const executePendingSidepanelCallback = (sidepanelWasOpen: boolean): void => {
+    if (! pendingSidepanelCallback) {
+        return;
+    }
+
+    const callback = pendingSidepanelCallback;
+    pendingSidepanelCallback = null;
+
+    callback(undefined, sidepanelWasOpen);
+};
+
+const createExtensionWindow = async (
+    tabId: number,
+    windowId: number | undefined,
+    onWindowReady: (id?: number, sidepanelWasOpen?: boolean) => void,
+) => {
+    if (sidepanelEnabled) {
+        pendingSidepanelCallback = onWindowReady;
+
+        // Open the side panel in the triggering window. chrome.sidePanel.open()
+        // is called before any other await so the user-gesture context from the
+        // content-script message is still active (Chrome 116+).
+        if (windowId !== undefined) {
+            await openSidepanel(windowId);
+        }
+
+        // Also notify an already-open panel so it re-processes without remounting.
+        runtime.sendMessage({ type: 'SIDEPANEL_CHECK_PENDING' }).catch(() => {});
+
+        return; // Never fall back to popup when side panel mode is enabled
+    }
+
     // Check if a window is already open
     if (extensionWindowId !== null) {
         await windows.update(extensionWindowId, { focused: true });
+
         return;
     }
 
@@ -112,12 +155,12 @@ const createExtensionWindow = async (onWindowReady: (id?: number) => void) => {
 };
 
 const initWindow = async (payload: EventPayload<ConnectData>) => {
-    await createExtensionWindow((id) => {
+    await createExtensionWindow(payload.data.tabId, payload.data.windowId, (id, sidepanelWasOpen) => {
         const { port, ...rest } = payload.data;
 
         runtime.sendMessage({
             type: `${payload.type}_UI`,
-            data: { ...rest, windowId: id },
+            data: { ...rest, windowId: id, sidepanelWasOpen },
         });
     });
 };
@@ -196,12 +239,12 @@ const handleDisconnect = async (
         assertHasWallet(profile);
         assertIsNotConnected({ payload, profile });
 
-        await createExtensionWindow((id) => {
+        await createExtensionWindow(payload.data.tabId, payload.data.windowId, (id, sidepanelWasOpen) => {
             const { port, ...rest } = payload.data;
 
             runtime.sendMessage({
                 type: `${payload.type}_UI`,
-                data: { ...rest, windowId: id },
+                data: { ...rest, windowId: id, sidepanelWasOpen },
             });
         });
     } catch (error: any) {
@@ -339,12 +382,12 @@ const handleSignMessage = async (
 
         const wallet = profile?.wallets().findById(activeSession.walletId);
 
-        await createExtensionWindow((id) => {
+        await createExtensionWindow(payload.data.tabId, payload.data.windowId, (id, sidepanelWasOpen) => {
             const { port, ...rest } = payload.data;
 
             runtime.sendMessage({
                 type: `${payload.type}_UI`,
-                data: { ...rest, session: { ...activeSession, wallet }, windowId: id },
+                data: { ...rest, session: { ...activeSession, wallet }, windowId: id, sidepanelWasOpen },
             });
         });
     } catch (error: any) {
@@ -373,12 +416,12 @@ const handleSignTransaction = async (
 
         const wallet = profile?.wallets().findById(activeSession.walletId);
 
-        await createExtensionWindow((id) => {
+        await createExtensionWindow(payload.data.tabId, payload.data.windowId, (id, sidepanelWasOpen) => {
             const { port, ...rest } = payload.data;
 
             runtime.sendMessage({
                 type: `${payload.type}_UI`,
-                data: { ...rest, session: { ...activeSession, wallet }, windowId: id },
+                data: { ...rest, session: { ...activeSession, wallet }, windowId: id, sidepanelWasOpen },
             });
         });
     } catch (error: any) {
@@ -407,12 +450,12 @@ const handleSignVote = async (
 
         const wallet = profile?.wallets().findById(activeSession.walletId);
 
-        await createExtensionWindow((id) => {
+        await createExtensionWindow(payload.data.tabId, payload.data.windowId, (id, sidepanelWasOpen) => {
             const { port, ...rest } = payload.data;
 
             runtime.sendMessage({
                 type: `${payload.type}_UI`,
-                data: { ...rest, session: { ...activeSession, wallet }, windowId: id },
+                data: { ...rest, session: { ...activeSession, wallet }, windowId: id, sidepanelWasOpen },
             });
         });
     } catch (error: any) {

--- a/src/lib/background/eventListenerHandlers.ts
+++ b/src/lib/background/eventListenerHandlers.ts
@@ -62,7 +62,7 @@ export const setSidepanelEnabled = (enabled: boolean): void => {
 };
 
 export const executePendingSidepanelCallback = (sidepanelWasOpen: boolean): void => {
-    if (! pendingSidepanelCallback) {
+    if (!pendingSidepanelCallback) {
         return;
     }
 
@@ -155,14 +155,18 @@ const createExtensionWindow = async (
 };
 
 const initWindow = async (payload: EventPayload<ConnectData>) => {
-    await createExtensionWindow(payload.data.tabId, payload.data.windowId, (id, sidepanelWasOpen) => {
-        const { port, ...rest } = payload.data;
+    await createExtensionWindow(
+        payload.data.tabId,
+        payload.data.windowId,
+        (id, sidepanelWasOpen) => {
+            const { port, ...rest } = payload.data;
 
-        runtime.sendMessage({
-            type: `${payload.type}_UI`,
-            data: { ...rest, windowId: id, sidepanelWasOpen },
-        });
-    });
+            runtime.sendMessage({
+                type: `${payload.type}_UI`,
+                data: { ...rest, windowId: id, sidepanelWasOpen },
+            });
+        },
+    );
 };
 
 const handleOnConnect = async (
@@ -239,14 +243,18 @@ const handleDisconnect = async (
         assertHasWallet(profile);
         assertIsNotConnected({ payload, profile });
 
-        await createExtensionWindow(payload.data.tabId, payload.data.windowId, (id, sidepanelWasOpen) => {
-            const { port, ...rest } = payload.data;
+        await createExtensionWindow(
+            payload.data.tabId,
+            payload.data.windowId,
+            (id, sidepanelWasOpen) => {
+                const { port, ...rest } = payload.data;
 
-            runtime.sendMessage({
-                type: `${payload.type}_UI`,
-                data: { ...rest, windowId: id, sidepanelWasOpen },
-            });
-        });
+                runtime.sendMessage({
+                    type: `${payload.type}_UI`,
+                    data: { ...rest, windowId: id, sidepanelWasOpen },
+                });
+            },
+        );
     } catch (error: any) {
         tabs.sendMessage(payload.data.tabId, {
             type: `${payload.type}_REJECT`,
@@ -382,14 +390,23 @@ const handleSignMessage = async (
 
         const wallet = profile?.wallets().findById(activeSession.walletId);
 
-        await createExtensionWindow(payload.data.tabId, payload.data.windowId, (id, sidepanelWasOpen) => {
-            const { port, ...rest } = payload.data;
+        await createExtensionWindow(
+            payload.data.tabId,
+            payload.data.windowId,
+            (id, sidepanelWasOpen) => {
+                const { port, ...rest } = payload.data;
 
-            runtime.sendMessage({
-                type: `${payload.type}_UI`,
-                data: { ...rest, session: { ...activeSession, wallet }, windowId: id, sidepanelWasOpen },
-            });
-        });
+                runtime.sendMessage({
+                    type: `${payload.type}_UI`,
+                    data: {
+                        ...rest,
+                        session: { ...activeSession, wallet },
+                        windowId: id,
+                        sidepanelWasOpen,
+                    },
+                });
+            },
+        );
     } catch (error: any) {
         tabs.sendMessage(payload.data.tabId, {
             type: `${payload.type}_REJECT`,
@@ -416,14 +433,23 @@ const handleSignTransaction = async (
 
         const wallet = profile?.wallets().findById(activeSession.walletId);
 
-        await createExtensionWindow(payload.data.tabId, payload.data.windowId, (id, sidepanelWasOpen) => {
-            const { port, ...rest } = payload.data;
+        await createExtensionWindow(
+            payload.data.tabId,
+            payload.data.windowId,
+            (id, sidepanelWasOpen) => {
+                const { port, ...rest } = payload.data;
 
-            runtime.sendMessage({
-                type: `${payload.type}_UI`,
-                data: { ...rest, session: { ...activeSession, wallet }, windowId: id, sidepanelWasOpen },
-            });
-        });
+                runtime.sendMessage({
+                    type: `${payload.type}_UI`,
+                    data: {
+                        ...rest,
+                        session: { ...activeSession, wallet },
+                        windowId: id,
+                        sidepanelWasOpen,
+                    },
+                });
+            },
+        );
     } catch (error: any) {
         tabs.sendMessage(payload.data.tabId, {
             type: `${payload.type}_REJECT`,
@@ -450,14 +476,23 @@ const handleSignVote = async (
 
         const wallet = profile?.wallets().findById(activeSession.walletId);
 
-        await createExtensionWindow(payload.data.tabId, payload.data.windowId, (id, sidepanelWasOpen) => {
-            const { port, ...rest } = payload.data;
+        await createExtensionWindow(
+            payload.data.tabId,
+            payload.data.windowId,
+            (id, sidepanelWasOpen) => {
+                const { port, ...rest } = payload.data;
 
-            runtime.sendMessage({
-                type: `${payload.type}_UI`,
-                data: { ...rest, session: { ...activeSession, wallet }, windowId: id, sidepanelWasOpen },
-            });
-        });
+                runtime.sendMessage({
+                    type: `${payload.type}_UI`,
+                    data: {
+                        ...rest,
+                        session: { ...activeSession, wallet },
+                        windowId: id,
+                        sidepanelWasOpen,
+                    },
+                });
+            },
+        );
     } catch (error: any) {
         tabs.sendMessage(payload.data.tabId, {
             type: `${payload.type}_REJECT`,

--- a/src/lib/background/sidepanel.ts
+++ b/src/lib/background/sidepanel.ts
@@ -7,6 +7,7 @@ declare const chrome: {
     sidePanel?: {
         setPanelBehavior(behavior: { openPanelOnActionClick: boolean }): Promise<void>;
         open(details: { windowId: number }): Promise<void>;
+        close(details: { windowId: number }): Promise<void>;
     };
 };
 
@@ -31,4 +32,8 @@ export const openPopupForWindow = async (windowId: number): Promise<void> => {
 
 export const openSidepanel = async (windowId: number): Promise<void> => {
     await chrome.sidePanel?.open({ windowId });
+};
+
+export const closeSidepanel = async (windowId: number): Promise<void> => {
+    await chrome.sidePanel?.close({ windowId });
 };

--- a/src/lib/hooks/useBackgroundEventHandler.ts
+++ b/src/lib/hooks/useBackgroundEventHandler.ts
@@ -19,12 +19,18 @@ export type Event = {
     };
 };
 
+const isSidepanel = () => window.location.href.includes('sidepanel');
+
 const useBackgroundEventHandler = () => {
     const dispatch = useAppDispatch();
     const [events, setEvents] = useState<Event[]>([]);
     const navigate = useNavigate();
 
     useEffect(() => {
+        if (isSidepanel()) {
+            runtime.sendMessage({ type: 'SIDEPANEL_READY', data: { wasAlreadyOpen: false } }).catch(() => {});
+        }
+
         // Listen for messages from background script
         runtime.onMessage.addListener(function (request) {
             switch (request.type) {
@@ -50,6 +56,12 @@ const useBackgroundEventHandler = () => {
                 }
                 case 'LOCK_EXTENSION_UI': {
                     setEvents([...events, { request, callback: onLockExtension }]);
+                    break;
+                }
+                case 'SIDEPANEL_CHECK_PENDING': {
+                    if (isSidepanel()) {
+                        runtime.sendMessage({ type: 'SIDEPANEL_READY', data: { wasAlreadyOpen: true } }).catch(() => {});
+                    }
                     break;
                 }
             }

--- a/src/lib/hooks/useBackgroundEventHandler.ts
+++ b/src/lib/hooks/useBackgroundEventHandler.ts
@@ -28,7 +28,9 @@ const useBackgroundEventHandler = () => {
 
     useEffect(() => {
         if (isSidepanel()) {
-            runtime.sendMessage({ type: 'SIDEPANEL_READY', data: { wasAlreadyOpen: false } }).catch(() => {});
+            runtime
+                .sendMessage({ type: 'SIDEPANEL_READY', data: { wasAlreadyOpen: false } })
+                .catch(() => {});
         }
 
         // Listen for messages from background script
@@ -60,7 +62,12 @@ const useBackgroundEventHandler = () => {
                 }
                 case 'SIDEPANEL_CHECK_PENDING': {
                     if (isSidepanel()) {
-                        runtime.sendMessage({ type: 'SIDEPANEL_READY', data: { wasAlreadyOpen: true } }).catch(() => {});
+                        runtime
+                            .sendMessage({
+                                type: 'SIDEPANEL_READY',
+                                data: { wasAlreadyOpen: true },
+                            })
+                            .catch(() => {});
                     }
                     break;
                 }

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { runtime, windows } from 'webextension-polyfill';
 import { useEffect, useMemo } from 'react';
@@ -15,10 +15,12 @@ import { assertIsUnlocked } from '@/lib/background/assertions';
 import ActionHeader from '@/shared/components/actions/ActionHeader';
 import { useNotifyOnUnload } from '@/lib/hooks/useNotifyOnUnload';
 import useLoadingModal from '@/lib/hooks/useLoadingModal';
+import removeWindowInstance from '@/lib/utils/removeWindowInstance';
 import { ApproveLayout } from '@/components/approve/ApproveLayout';
 
 const Connect = () => {
     const location = useLocation();
+    const navigate = useNavigate();
     const dispatch = useAppDispatch();
     const sessions = useAppSelector(SessionStore.selectSessions);
     const { profile } = useProfileContext();
@@ -48,19 +50,34 @@ const Connect = () => {
         }
     }, []);
 
-    const reject = (message = t('PAGES.CONNECT.FEEDBACK.CONNECTION_DENIED')) => {
+    const reject = (message?: string) => {
         runtime.sendMessage({
             type: 'CONNECT_REJECT',
             data: {
                 domain: location.state?.domain,
                 status: 'failed',
-                message,
+                message: typeof message === 'string' ? message : t('PAGES.CONNECT.FEEDBACK.CONNECTION_DENIED'),
                 tabId: location.state?.tabId,
             },
-        });
+        }).catch(() => {});
     };
 
     const setSubmitted = useNotifyOnUnload(reject);
+
+    const closeSidepanel = async () => {
+        const win = await windows.getCurrent();
+        if (win.id !== undefined) {
+            await runtime.sendMessage({ type: 'CLOSE_SIDEPANEL', data: { windowId: win.id } });
+        }
+    };
+
+    const dismissSidepanel = async () => {
+        if (location.state?.sidepanelWasOpen) {
+            navigate(-1);
+        } else {
+            await closeSidepanel();
+        }
+    };
 
     const onSubmit = async () => {
         loadingModal.setLoading();
@@ -99,14 +116,23 @@ const Connect = () => {
 
             setSubmitted();
 
-            await windows.remove(location.state?.windowId);
+            if (location.state?.windowId) {
+                await removeWindowInstance(location.state.windowId);
+            } else {
+                await loadingModal.setCompletedAndClose();
+                await dismissSidepanel();
+            }
             return;
         }
     };
 
     const onCancel = async (message?: string) => {
         reject(message);
-        await windows.remove(location.state?.windowId);
+        if (location.state?.windowId) {
+            await removeWindowInstance(location.state.windowId);
+        } else {
+            await dismissSidepanel();
+        }
     };
 
     return (

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -51,15 +51,20 @@ const Connect = () => {
     }, []);
 
     const reject = (message?: string) => {
-        runtime.sendMessage({
-            type: 'CONNECT_REJECT',
-            data: {
-                domain: location.state?.domain,
-                status: 'failed',
-                message: typeof message === 'string' ? message : t('PAGES.CONNECT.FEEDBACK.CONNECTION_DENIED'),
-                tabId: location.state?.tabId,
-            },
-        }).catch(() => {});
+        runtime
+            .sendMessage({
+                type: 'CONNECT_REJECT',
+                data: {
+                    domain: location.state?.domain,
+                    status: 'failed',
+                    message:
+                        typeof message === 'string'
+                            ? message
+                            : t('PAGES.CONNECT.FEEDBACK.CONNECTION_DENIED'),
+                    tabId: location.state?.tabId,
+                },
+            })
+            .catch(() => {});
     };
 
     const setSubmitted = useNotifyOnUnload(reject);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86e1m47dc

I included additional handling of the sidebar to close it if it wasn't open initially, or to go back to the previous page if it was already open at the time the webapp connect was initiated

Note: I did have some help from Claude with this

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
