### PR TITLE
refactor: close sidebar when opened from webapp

### DIFF
--- a/src/components/approve/ApproveMessage.tsx
+++ b/src/components/approve/ApproveMessage.tsx
@@ -1,5 +1,5 @@
-import { useLocation } from 'react-router-dom';
-import { runtime } from 'webextension-polyfill';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { runtime, windows } from 'webextension-polyfill';
 import { useTranslation } from 'react-i18next';
 import { ApproveLayout } from './ApproveLayout';
 import { Contracts } from '@/lib/profiles';
@@ -48,6 +48,22 @@ const ApproveMessage = ({
         loadingMessage: t('PAGES.APPROVE.FEEDBACK.SIGNING'),
     });
     const { waitUntilLedgerIsConnected } = useWaitForConnectedDevice();
+    const navigate = useNavigate();
+
+    const closeSidepanel = async () => {
+        const win = await windows.getCurrent();
+        if (win.id !== undefined) {
+            await runtime.sendMessage({ type: 'CLOSE_SIDEPANEL', data: { windowId: win.id } });
+        }
+    };
+
+    const dismissSidepanel = async () => {
+        if (location.state?.sidepanelWasOpen) {
+            navigate(-1);
+        } else {
+            await closeSidepanel();
+        }
+    };
 
     const reject = (message: string = t('PAGES.APPROVE.FEEDBACK.SIGN_MESSAGE_DENIED')) => {
         runtime.sendMessage({
@@ -100,12 +116,16 @@ const ApproveMessage = ({
 
             setSubmitted();
 
-            loadingModal.setCompleted();
-
-            await removeWindowInstance(
-                location.state?.windowId,
-                constants.SHOW_MESSAGE_AFTER_ACTION_DURING_MS,
-            );
+            if (location.state?.windowId) {
+                loadingModal.setCompleted();
+                await removeWindowInstance(
+                    location.state.windowId,
+                    constants.SHOW_MESSAGE_AFTER_ACTION_DURING_MS,
+                );
+            } else {
+                await loadingModal.setCompletedAndClose();
+                await dismissSidepanel();
+            }
         } catch (error: any) {
             if (wallet.isLedger()) {
                 closeLedgerScreen();
@@ -121,7 +141,11 @@ const ApproveMessage = ({
 
         loadingModal.close();
 
-        await removeWindowInstance(location.state?.windowId, 100);
+        if (location.state?.windowId) {
+            await removeWindowInstance(location.state.windowId, 100);
+        } else {
+            await dismissSidepanel();
+        }
     };
 
     return (

--- a/src/components/approve/ApproveTransaction.tsx
+++ b/src/components/approve/ApproveTransaction.tsx
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { runtime } from 'webextension-polyfill';
+import { runtime, windows } from 'webextension-polyfill';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from 'react-query';
 import { ApproveLayout } from './ApproveLayout';
@@ -75,6 +75,21 @@ const ApproveTransaction = ({
     const coin = getNetworkCurrency(wallet.network());
     const withFiat = wallet.network().isLive();
     const isNative = session.domain === constants.APP_NAME;
+
+    const closeSidepanel = async () => {
+        const win = await windows.getCurrent();
+        if (win.id !== undefined) {
+            await runtime.sendMessage({ type: 'CLOSE_SIDEPANEL', data: { windowId: win.id } });
+        }
+    };
+
+    const dismissSidepanel = async () => {
+        if (location.state?.sidepanelWasOpen) {
+            navigate(-1);
+        } else {
+            await closeSidepanel();
+        }
+    };
 
     const { data: token } = useQuery<WalletToken | undefined>(
         ['approve-token', wallet?.address(), tokenAddress],
@@ -214,6 +229,7 @@ const ApproveTransaction = ({
                     transaction,
                     walletId: wallet.id(),
                     windowId: location.state?.windowId,
+                    sidepanelWasOpen: location.state?.sidepanelWasOpen,
                     walletNetwork: wallet.network().isTest()
                         ? WalletNetwork.DEVNET
                         : WalletNetwork.MAINNET,
@@ -254,20 +270,32 @@ const ApproveTransaction = ({
 
         reject();
 
-        if (location.state.windowId) {
-            await removeWindowInstance(location.state?.windowId, 100);
-        }
         loadingModal.close();
 
-        const params = new URLSearchParams({
-            receiverAddress,
-            amount,
-            gasPrice: customGasPrice,
-            gasLimit: customGasLimit,
-            feeClass,
-            ...(tokenAddress ? { token: tokenAddress } : {}),
-        });
-        navigate(isNative ? `/transaction/send?${params.toString()}` : '/');
+        if (location.state.windowId) {
+            await removeWindowInstance(location.state?.windowId, 100);
+            const params = new URLSearchParams({
+                receiverAddress,
+                amount,
+                gasPrice: customGasPrice,
+                gasLimit: customGasLimit,
+                feeClass,
+                ...(tokenAddress ? { token: tokenAddress } : {}),
+            });
+            navigate(isNative ? `/transaction/send?${params.toString()}` : '/');
+        } else if (isNative) {
+            const params = new URLSearchParams({
+                receiverAddress,
+                amount,
+                gasPrice: customGasPrice,
+                gasLimit: customGasLimit,
+                feeClass,
+                ...(tokenAddress ? { token: tokenAddress } : {}),
+            });
+            navigate(`/transaction/send?${params.toString()}`);
+        } else {
+            await dismissSidepanel();
+        }
     };
 
     return (

--- a/src/components/approve/ApproveVote.tsx
+++ b/src/components/approve/ApproveVote.tsx
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { runtime } from 'webextension-polyfill';
+import { runtime, windows } from 'webextension-polyfill';
 import { useTranslation } from 'react-i18next';
 import { ApproveLayout } from './ApproveLayout';
 import { Contracts } from '@/lib/profiles';
@@ -60,6 +60,21 @@ const ApproveVote = ({ abortReference, approveWithLedger, wallet, closeLedgerScr
     } = location.state;
     const [showHigherCustomFeeBanner, setShowHigherCustomFeeBanner] = useState(true);
     const isNative = session.domain === constants.APP_NAME;
+
+    const closeSidepanel = async () => {
+        const win = await windows.getCurrent();
+        if (win.id !== undefined) {
+            await runtime.sendMessage({ type: 'CLOSE_SIDEPANEL', data: { windowId: win.id } });
+        }
+    };
+
+    const dismissSidepanel = async () => {
+        if (location.state?.sidepanelWasOpen) {
+            navigate(-1);
+        } else {
+            await closeSidepanel();
+        }
+    };
 
     const {
         resetForm,
@@ -173,6 +188,7 @@ const ApproveVote = ({ abortReference, approveWithLedger, wallet, closeLedgerScr
                 state: {
                     vote: voteInfo,
                     windowId: location.state?.windowId,
+                    sidepanelWasOpen: location.state?.sidepanelWasOpen,
                     walletNetwork: wallet.network().isTest()
                         ? WalletNetwork.DEVNET
                         : WalletNetwork.MAINNET,
@@ -205,23 +221,35 @@ const ApproveVote = ({ abortReference, approveWithLedger, wallet, closeLedgerScr
 
         reject();
 
-        if (location.state.windowId) {
-            await removeWindowInstance(location.state?.windowId, 100);
-        }
         loadingModal.close();
 
-        const params = new URLSearchParams({
-            gasPrice: customGasPrice,
-            gasLimit: customGasLimit,
-            feeClass,
-        });
-        params.append('vote', vote?.wallet?.address() ?? '');
-        params.append('unvote', unvote?.wallet?.address() ?? '');
-        if (isNative) {
+        if (location.state.windowId) {
+            await removeWindowInstance(location.state?.windowId, 100);
+            const params = new URLSearchParams({
+                gasPrice: customGasPrice,
+                gasLimit: customGasLimit,
+                feeClass,
+            });
+            params.append('vote', vote?.wallet?.address() ?? '');
+            params.append('unvote', unvote?.wallet?.address() ?? '');
+            if (isNative) {
+                profile.settings().forget('LAST_VISITED_PAGE');
+                navigate(`/vote?${params.toString()}`);
+            } else {
+                navigate('/');
+            }
+        } else if (isNative) {
+            const params = new URLSearchParams({
+                gasPrice: customGasPrice,
+                gasLimit: customGasLimit,
+                feeClass,
+            });
+            params.append('vote', vote?.wallet?.address() ?? '');
+            params.append('unvote', unvote?.wallet?.address() ?? '');
             profile.settings().forget('LAST_VISITED_PAGE');
             navigate(`/vote?${params.toString()}`);
         } else {
-            navigate('/');
+            await dismissSidepanel();
         }
     };
 

--- a/src/lib/context/ErrorHandler.tsx
+++ b/src/lib/context/ErrorHandler.tsx
@@ -1,5 +1,6 @@
 import { createContext, ReactNode, useContext, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { runtime, windows } from 'webextension-polyfill';
 import useOnError from '@/lib/hooks';
 import removeWindowInstance from '@/lib/utils/removeWindowInstance';
 import ErrorModal from '@/components/connect/ErrorModal';
@@ -29,12 +30,23 @@ export const ErrorHandlerProvider = ({ children }: Properties) => {
         }
     };
 
+    const closeSidepanel = async () => {
+        const win = await windows.getCurrent();
+        if (win.id !== undefined) {
+            await runtime.sendMessage({ type: 'CLOSE_SIDEPANEL', data: { windowId: win.id } });
+        }
+    };
+
     const handleClose = async () => {
         setShowErrorModal(false);
         if (state?.windowId) {
             await removeWindowInstance(state?.windowId);
+            navigate('/');
+        } else if (state?.sidepanelWasOpen) {
+            navigate('/');
+        } else {
+            await closeSidepanel();
         }
-        navigate('/');
     };
 
     const handleBack = () => {

--- a/src/pages/TransactionApproved.tsx
+++ b/src/pages/TransactionApproved.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { runtime, windows } from 'webextension-polyfill';
 import { BigNumber } from '../lib/helpers';
 import { useEnvironmentContext } from '@/lib/context/Environment';
 import { useProfileContext } from '@/lib/context/Profile';
@@ -61,11 +62,22 @@ const TransactionApproved = () => {
     const { env } = useEnvironmentContext();
     const { session } = state;
     const { t } = useTranslation();
+    const closeSidepanel = async () => {
+        const win = await windows.getCurrent();
+        if (win.id !== undefined) {
+            await runtime.sendMessage({ type: 'CLOSE_SIDEPANEL', data: { windowId: win.id } });
+        }
+    };
+
     const onClose = async () => {
         if (state?.windowId) {
             await removeWindowInstance(state?.windowId);
+            navigate('/');
+        } else if (state?.sidepanelWasOpen) {
+            navigate('/');
+        } else {
+            await closeSidepanel();
         }
-        navigate('/');
     };
 
     const transactionId = state?.transaction.id;

--- a/src/pages/VoteApproved.tsx
+++ b/src/pages/VoteApproved.tsx
@@ -1,7 +1,7 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useEffect } from 'react';
-import { runtime } from 'webextension-polyfill';
+import { runtime, windows } from 'webextension-polyfill';
 import { BigNumber } from '../lib/helpers';
 import { ApproveActionType } from './Approve';
 import removeWindowInstance from '@/lib/utils/removeWindowInstance';
@@ -71,12 +71,22 @@ const VoteApproved = () => {
 
     const isTransactionConfirmed = useConfirmedTransaction({ wallet, transactionId: vote.id });
 
+    const closeSidepanel = async () => {
+        const win = await windows.getCurrent();
+        if (win.id !== undefined) {
+            await runtime.sendMessage({ type: 'CLOSE_SIDEPANEL', data: { windowId: win.id } });
+        }
+    };
+
     const onClose = async () => {
         if (state?.windowId) {
             await removeWindowInstance(state?.windowId);
+            navigate('/');
+        } else if (state?.sidepanelWasOpen) {
+            navigate('/');
+        } else {
+            await closeSidepanel();
         }
-
-        navigate('/');
     };
     useEffect(() => {
         runtime.sendMessage({ type: 'CLEAR_LAST_SCREEN' });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/2570579/86e1rk1rz

this adjusts how the sidebar is closed when opened using the arkconnect webapp. if it wasn't open and something initiated the extension (sign, vote, send), it should close at the end of the process, or once a close button is pressed if it exists.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

- [ ] I checked that both `pnpm dev` and `pnpm dev:bare` work as intended
- [ ] I checked the basic extension interactions and made sure wallet selection works
- [ ] I checked my UI changes against the design and there are no notable differences, including responsiveness
- [ ] I checked my (code) changes for obvious issues, debug statements and commented code
- [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
- [ ] I added a short description on how to test this PR _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
